### PR TITLE
Patch littlefs2 dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,8 +123,10 @@ clients-11 = []
 clients-12 = []
 
 test-attestation-cert-ids = []
-# [patch.crates-io]
+
+[patch.crates-io]
 # interchange = { git = "https://github.com/trussed-dev/interchange", branch = "main" }
+littlefs2 = { git = "https://github.com/Nitrokey/littlefs2", tag = "v0.3.2-nitrokey-1" }
 
 [package.metadata.docs.rs]
 features = ["virt"]

--- a/src/virt/store.rs
+++ b/src/virt/store.rs
@@ -47,7 +47,7 @@ impl Storage for FilesystemStorage {
     // TODO: This can't actually be changed currently
     // type ATTRBYTES_MAX = U1022;
 
-    fn read(&self, offset: usize, buffer: &mut [u8]) -> LfsResult<usize> {
+    fn read(&mut self, offset: usize, buffer: &mut [u8]) -> LfsResult<usize> {
         let mut file = File::open(&self.0).unwrap();
         file.seek(SeekFrom::Start(offset as _)).unwrap();
         let bytes_read = file.read(buffer).unwrap();


### PR DESCRIPTION
This is required for compatibility with nitrokey-3-firmware.