### PR TITLE
Add support for multiple backends

### DIFF
--- a/.github/workflows/firmwares.yml
+++ b/.github/workflows/firmwares.yml
@@ -22,11 +22,11 @@ jobs:
       - name: Checkout Nitrokey/nitrokey-3-firmware
         run: git clone https://github.com/Nitrokey/nitrokey-3-firmware nk3
 
-      - name: Install littlefs2-sys/micro-ecc-sys build dependencies
+      - name: Install littlefs2-sys/micro-ecc-sys/nitrokey-3-firmware build dependencies
         shell: bash
         run: |
           apt-get update && apt-get install sudo
-          env && pwd && sudo apt-get update -y -qq && sudo apt-get install -y -qq llvm libc6-dev-i386 libclang-dev clang git
+          env && pwd && sudo apt-get update -y -qq && sudo apt-get install -y -qq llvm libc6-dev-i386 libclang-dev clang git python3-toml
 
       - uses: fiam/arm-none-eabi-gcc@v1
         with:
@@ -69,4 +69,4 @@ jobs:
         run: make build-release -C solo2/runners/lpc55
       
       - name: Build Nitrokey-3 Firmware
-        run: make -C nk3/runners/lpc55
+        run: make -C nk3/runners/embedded

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ cfg-if = "1.0"
 embedded-hal = { version = "0.2.3", features = ["unproven"] }
 flexiber = { version = "0.1.0", features = ["derive", "heapless"] }
 generic-array = "0.14.4"
-heapless = { version = "0.7", features = ["serde"] }
+heapless = { version = "0.7.15", features = ["serde"] }
 hex-literal = "0.3.1"
 nb = "1"
 postcard = "0.7.0"

--- a/src/api.rs
+++ b/src/api.rs
@@ -336,75 +336,9 @@ pub mod request {
         WriteCertificate:
           - location: Location
           - der: Message
-    }
 
-    // TODO: auto-generate once serde_indexed works for generic structs
-
-    #[derive(Clone, Eq, PartialEq, Debug)]
-    pub struct SetServiceBackends<B> {
-        pub backends: Vec<ServiceBackends<B>, 2>,
-    }
-
-    impl<B> From<SetServiceBackends<B>> for Request<B> {
-        fn from(request: SetServiceBackends<B>) -> Self {
-            Self::SetServiceBackends(request)
-        }
-    }
-
-    impl<'de, B: serde::Deserialize<'de>> serde::Deserialize<'de> for SetServiceBackends<B> {
-        fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
-        where
-            D: serde::Deserializer<'de>,
-        {
-            struct IndexedVisitor<B>(core::marker::PhantomData<B>);
-            impl<'de, B: serde::Deserialize<'de>> serde::de::Visitor<'de> for IndexedVisitor<B> {
-                type Value = SetServiceBackends<B>;
-                fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
-                    formatter.write_str("SetServiceBackends")
-                }
-                fn visit_map<V>(
-                    self,
-                    mut map: V,
-                ) -> core::result::Result<SetServiceBackends<B>, V::Error>
-                where
-                    V: serde::de::MapAccess<'de>,
-                {
-                    let mut backends = None;
-                    while let Some(__serde_indexed_internal_key) = map.next_key()? {
-                        match __serde_indexed_internal_key {
-                            0usize => {
-                                if backends.is_some() {
-                                    return Err(serde::de::Error::duplicate_field("backends"));
-                                }
-                                backends = Some(map.next_value()?);
-                            }
-                            _ => {
-                                return Err(serde::de::Error::duplicate_field(
-                                    "inexistent field index",
-                                ));
-                            }
-                        }
-                    }
-                    let backends =
-                        backends.ok_or_else(|| serde::de::Error::missing_field("backends"))?;
-                    Ok(SetServiceBackends { backends })
-                }
-            }
-            deserializer.deserialize_map(IndexedVisitor(Default::default()))
-        }
-    }
-
-    impl<B: serde::Serialize> serde::Serialize for SetServiceBackends<B> {
-        fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
-        where
-            S: serde::Serializer,
-        {
-            use serde::ser::SerializeMap;
-            let num_fields = 0 + 1;
-            let mut map = serializer.serialize_map(Some(num_fields))?;
-            map.serialize_entry(&0usize, &self.backends)?;
-            map.end()
-        }
+        SetServiceBackends<B>:
+          - backends: Vec<ServiceBackends<B>, 2>
     }
 }
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -102,7 +102,7 @@ generate_enums! {
     ///////////////////
     // Backend Mgmt. //
     ///////////////////
-    SetServiceBackends: 90
+    SetServiceBackends<B>: 90
 
     ///////////
     // Other //
@@ -336,9 +336,75 @@ pub mod request {
         WriteCertificate:
           - location: Location
           - der: Message
+    }
 
-        SetServiceBackends:
-          - backends: Vec<ServiceBackends, 2>
+    // TODO: auto-generate once serde_indexed works for generic structs
+
+    #[derive(Clone, Eq, PartialEq, Debug)]
+    pub struct SetServiceBackends<B> {
+        pub backends: Vec<ServiceBackends<B>, 2>,
+    }
+
+    impl<B> From<SetServiceBackends<B>> for Request<B> {
+        fn from(request: SetServiceBackends<B>) -> Self {
+            Self::SetServiceBackends(request)
+        }
+    }
+
+    impl<'de, B: serde::Deserialize<'de>> serde::Deserialize<'de> for SetServiceBackends<B> {
+        fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            struct IndexedVisitor<B>(core::marker::PhantomData<B>);
+            impl<'de, B: serde::Deserialize<'de>> serde::de::Visitor<'de> for IndexedVisitor<B> {
+                type Value = SetServiceBackends<B>;
+                fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
+                    formatter.write_str("SetServiceBackends")
+                }
+                fn visit_map<V>(
+                    self,
+                    mut map: V,
+                ) -> core::result::Result<SetServiceBackends<B>, V::Error>
+                where
+                    V: serde::de::MapAccess<'de>,
+                {
+                    let mut backends = None;
+                    while let Some(__serde_indexed_internal_key) = map.next_key()? {
+                        match __serde_indexed_internal_key {
+                            0usize => {
+                                if backends.is_some() {
+                                    return Err(serde::de::Error::duplicate_field("backends"));
+                                }
+                                backends = Some(map.next_value()?);
+                            }
+                            _ => {
+                                return Err(serde::de::Error::duplicate_field(
+                                    "inexistent field index",
+                                ));
+                            }
+                        }
+                    }
+                    let backends =
+                        backends.ok_or_else(|| serde::de::Error::missing_field("backends"))?;
+                    Ok(SetServiceBackends { backends })
+                }
+            }
+            deserializer.deserialize_map(IndexedVisitor(Default::default()))
+        }
+    }
+
+    impl<B: serde::Serialize> serde::Serialize for SetServiceBackends<B> {
+        fn serialize<S>(&self, serializer: S) -> core::result::Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            use serde::ser::SerializeMap;
+            let num_fields = 0 + 1;
+            let mut map = serializer.serialize_map(Some(num_fields))?;
+            map.serialize_entry(&0usize, &self.backends)?;
+            map.end()
+        }
     }
 }
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -99,6 +99,11 @@ generate_enums! {
     ReadCertificate: 61
     WriteCertificate: 62
 
+    ///////////////////
+    // Backend Mgmt. //
+    ///////////////////
+    SetServiceBackends: 90
+
     ///////////
     // Other //
     ///////////
@@ -332,6 +337,8 @@ pub mod request {
           - location: Location
           - der: Message
 
+        SetServiceBackends:
+          - backends: Vec<ServiceBackends, 2>
     }
 }
 
@@ -482,5 +489,8 @@ pub mod reply {
 
         WriteCertificate:
           - id: CertId
+
+        SetServiceBackends:
+
     }
 }

--- a/src/api.rs
+++ b/src/api.rs
@@ -337,8 +337,8 @@ pub mod request {
           - location: Location
           - der: Message
 
-        SetServiceBackends<B>:
-          - backends: Vec<ServiceBackends<B>, 2>
+        SetServiceBackends<B: 'static>:
+          - backends: &'static [ServiceBackends<B>]
     }
 }
 

--- a/src/api/macros.rs
+++ b/src/api/macros.rs
@@ -3,7 +3,7 @@ macro_rules! generate_enums {
 
     #[derive(Clone, Eq, PartialEq, Debug)]
     #[allow(clippy::large_enum_variant)]
-    pub enum Request<B> {
+    pub enum Request<B: 'static> {
         DummyRequest, // for testing
         $(
         $which(request::$which$(<$param>)?),
@@ -19,7 +19,7 @@ macro_rules! generate_enums {
         )*
     }
 
-    impl<B> From<&Request<B>> for u8 {
+    impl<B: 'static> From<&Request<B>> for u8 {
         fn from(request: &Request<B>) -> u8 {
             match request {
                 Request::DummyRequest => 0,
@@ -45,18 +45,18 @@ macro_rules! generate_enums {
 
 macro_rules! impl_request {
     ($(
-        $request:ident$(<$param:ident>)?:
-            $(- $name:tt: $type:path)*
+        $request:ident$(<$param:ident$(: $param_lt:lifetime)?>)?:
+            $(- $name:tt: $type:ty)*
     )*)
         => {$(
     #[derive(Clone, Eq, PartialEq, Debug)]
-    pub struct $request$(<$param>)? {
+    pub struct $request$(<$param$(: $param_lt)?>)? {
         $(
             pub $name: $type,
         )*
     }
 
-    impl<B> From<$request$(<$param>)?> for Request<B> {
+    impl<B: 'static> From<$request$(<$param>)?> for Request<B> {
         fn from(request: $request$(<$param>)?) -> Self {
             Self::$request(request)
         }

--- a/src/api/macros.rs
+++ b/src/api/macros.rs
@@ -1,12 +1,12 @@
 macro_rules! generate_enums {
-    ($($which:ident: $index:literal)*) => {
+    ($($which:ident$(<$param:ident>)?: $index:literal)*) => {
 
     #[derive(Clone, Eq, PartialEq, Debug)]
     #[allow(clippy::large_enum_variant)]
-    pub enum Request {
+    pub enum Request<B> {
         DummyRequest, // for testing
         $(
-        $which(request::$which),
+        $which(request::$which$(<$param>)?),
         )*
     }
 
@@ -19,8 +19,8 @@ macro_rules! generate_enums {
         )*
     }
 
-    impl From<&Request> for u8 {
-        fn from(request: &Request) -> u8 {
+    impl<B> From<&Request<B>> for u8 {
+        fn from(request: &Request<B>) -> u8 {
             match request {
                 Request::DummyRequest => 0,
                 $(
@@ -45,19 +45,19 @@ macro_rules! generate_enums {
 
 macro_rules! impl_request {
     ($(
-        $request:ident:
+        $request:ident$(<$param:ident>)?:
             $(- $name:tt: $type:path)*
     )*)
         => {$(
     #[derive(Clone, Eq, PartialEq, Debug, serde_indexed::DeserializeIndexed, serde_indexed::SerializeIndexed)]
-    pub struct $request {
+    pub struct $request$(<$param>)? {
         $(
             pub $name: $type,
         )*
     }
 
-    impl From<$request> for Request {
-        fn from(request: $request) -> Self {
+    impl<B> From<$request$(<$param>)?> for Request<B> {
+        fn from(request: $request$(<$param>)?) -> Self {
             Self::$request(request)
         }
     }

--- a/src/api/macros.rs
+++ b/src/api/macros.rs
@@ -49,7 +49,7 @@ macro_rules! impl_request {
             $(- $name:tt: $type:path)*
     )*)
         => {$(
-    #[derive(Clone, Eq, PartialEq, Debug, serde_indexed::DeserializeIndexed, serde_indexed::SerializeIndexed)]
+    #[derive(Clone, Eq, PartialEq, Debug)]
     pub struct $request$(<$param>)? {
         $(
             pub $name: $type,

--- a/src/client.rs
+++ b/src/client.rs
@@ -81,6 +81,7 @@ use interchange::{Interchange, Requester};
 
 use crate::api::*;
 use crate::error::*;
+use crate::pipe::TrussedInterchange;
 use crate::types::*;
 
 pub use crate::platform::Syscall;
@@ -105,10 +106,7 @@ pub trait Client:
 {
 }
 
-impl<I: Interchange<REQUEST = Request, RESPONSE = Result<Reply>> + 'static, S: Syscall> Client
-    for ClientImplementation<I, S>
-{
-}
+impl<I: TrussedInterchange, S: Syscall> Client for ClientImplementation<I, S> {}
 
 /// Lowest level interface, use one of the higher level ones.
 pub trait PollClient {
@@ -188,7 +186,7 @@ where
 
 impl<I, S> PollClient for ClientImplementation<I, S>
 where
-    I: Interchange<REQUEST = Request, RESPONSE = Result<Reply>> + 'static,
+    I: TrussedInterchange,
     S: Syscall,
 {
     fn poll(&mut self) -> core::task::Poll<core::result::Result<Reply, Error>> {
@@ -256,35 +254,17 @@ where
     }
 }
 
-impl<I: Interchange<REQUEST = Request, RESPONSE = Result<Reply>> + 'static, S: Syscall>
-    CertificateClient for ClientImplementation<I, S>
-{
-}
+impl<I: TrussedInterchange, S: Syscall> CertificateClient for ClientImplementation<I, S> {}
 
-impl<I: Interchange<REQUEST = Request, RESPONSE = Result<Reply>> + 'static, S: Syscall> CryptoClient
-    for ClientImplementation<I, S>
-{
-}
+impl<I: TrussedInterchange, S: Syscall> CryptoClient for ClientImplementation<I, S> {}
 
-impl<I: Interchange<REQUEST = Request, RESPONSE = Result<Reply>> + 'static, S: Syscall>
-    CounterClient for ClientImplementation<I, S>
-{
-}
+impl<I: TrussedInterchange, S: Syscall> CounterClient for ClientImplementation<I, S> {}
 
-impl<I: Interchange<REQUEST = Request, RESPONSE = Result<Reply>> + 'static, S: Syscall>
-    FilesystemClient for ClientImplementation<I, S>
-{
-}
+impl<I: TrussedInterchange, S: Syscall> FilesystemClient for ClientImplementation<I, S> {}
 
-impl<I: Interchange<REQUEST = Request, RESPONSE = Result<Reply>> + 'static, S: Syscall>
-    ManagementClient for ClientImplementation<I, S>
-{
-}
+impl<I: TrussedInterchange, S: Syscall> ManagementClient for ClientImplementation<I, S> {}
 
-impl<I: Interchange<REQUEST = Request, RESPONSE = Result<Reply>> + 'static, S: Syscall> UiClient
-    for ClientImplementation<I, S>
-{
-}
+impl<I: TrussedInterchange, S: Syscall> UiClient for ClientImplementation<I, S> {}
 
 /// Read/Write + Delete certificates
 pub trait CertificateClient: PollClient {

--- a/src/client.rs
+++ b/src/client.rs
@@ -116,6 +116,7 @@ pub trait PollClient {
     ) -> ClientResult<'_, T, Self>;
     fn poll(&mut self) -> core::task::Poll<core::result::Result<Reply, Error>>;
     fn syscall(&mut self);
+    fn set_service_backends(&mut self, backends: Vec<ServiceBackends, 2>) -> ClientResult<'_, reply::SetServiceBackends, Self>;
 }
 
 pub struct FutureResult<'c, T, C: ?Sized>
@@ -237,6 +238,15 @@ where
     fn syscall(&mut self) {
         self.syscall.syscall()
     }
+
+    fn set_service_backends(&mut self, backends: Vec<ServiceBackends, 2>)
+        -> ClientResult<'_, reply::SetServiceBackends, Self>
+    {
+        let r = self.request(request::SetServiceBackends { backends })?;
+        r.client.syscall();
+        Ok(r)
+    }
+
 }
 
 impl<S: Syscall> CertificateClient for ClientImplementation<S> {}

--- a/src/client.rs
+++ b/src/client.rs
@@ -116,7 +116,10 @@ pub trait PollClient {
     ) -> ClientResult<'_, T, Self>;
     fn poll(&mut self) -> core::task::Poll<core::result::Result<Reply, Error>>;
     fn syscall(&mut self);
-    fn set_service_backends(&mut self, backends: Vec<ServiceBackends, 2>) -> ClientResult<'_, reply::SetServiceBackends, Self>;
+    fn set_service_backends(
+        &mut self,
+        backends: Vec<ServiceBackends, 2>,
+    ) -> ClientResult<'_, reply::SetServiceBackends, Self>;
 }
 
 pub struct FutureResult<'c, T, C: ?Sized>
@@ -239,14 +242,14 @@ where
         self.syscall.syscall()
     }
 
-    fn set_service_backends(&mut self, backends: Vec<ServiceBackends, 2>)
-        -> ClientResult<'_, reply::SetServiceBackends, Self>
-    {
+    fn set_service_backends(
+        &mut self,
+        backends: Vec<ServiceBackends, 2>,
+    ) -> ClientResult<'_, reply::SetServiceBackends, Self> {
         let r = self.request(request::SetServiceBackends { backends })?;
         r.client.syscall();
         Ok(r)
     }
-
 }
 
 impl<S: Syscall> CertificateClient for ClientImplementation<S> {}

--- a/src/client.rs
+++ b/src/client.rs
@@ -106,11 +106,11 @@ pub trait Client:
 {
 }
 
-impl<B, I: TrussedInterchange<B>, S: Syscall> Client for ClientImplementation<B, I, S> {}
+impl<B: 'static, I: TrussedInterchange<B>, S: Syscall> Client for ClientImplementation<B, I, S> {}
 
 /// Lowest level interface, use one of the higher level ones.
 pub trait PollClient {
-    type Backend;
+    type Backend: 'static;
 
     fn request<T: From<crate::api::Reply>>(
         &mut self,
@@ -120,7 +120,7 @@ pub trait PollClient {
     fn syscall(&mut self);
     fn set_service_backends(
         &mut self,
-        backends: Vec<ServiceBackends<Self::Backend>, 2>,
+        backends: &'static [ServiceBackends<Self::Backend>],
     ) -> ClientResult<'_, reply::SetServiceBackends, Self>;
 }
 
@@ -190,6 +190,7 @@ where
 
 impl<B, I, S> PollClient for ClientImplementation<B, I, S>
 where
+    B: 'static,
     I: TrussedInterchange<B>,
     S: Syscall,
 {
@@ -252,7 +253,7 @@ where
 
     fn set_service_backends(
         &mut self,
-        backends: Vec<ServiceBackends<B>, 2>,
+        backends: &'static [ServiceBackends<B>],
     ) -> ClientResult<'_, reply::SetServiceBackends, Self> {
         let r = self.request(request::SetServiceBackends { backends })?;
         r.client.syscall();
@@ -260,17 +261,32 @@ where
     }
 }
 
-impl<B, I: TrussedInterchange<B>, S: Syscall> CertificateClient for ClientImplementation<B, I, S> {}
+impl<B: 'static, I: TrussedInterchange<B>, S: Syscall> CertificateClient
+    for ClientImplementation<B, I, S>
+{
+}
 
-impl<B, I: TrussedInterchange<B>, S: Syscall> CryptoClient for ClientImplementation<B, I, S> {}
+impl<B: 'static, I: TrussedInterchange<B>, S: Syscall> CryptoClient
+    for ClientImplementation<B, I, S>
+{
+}
 
-impl<B, I: TrussedInterchange<B>, S: Syscall> CounterClient for ClientImplementation<B, I, S> {}
+impl<B: 'static, I: TrussedInterchange<B>, S: Syscall> CounterClient
+    for ClientImplementation<B, I, S>
+{
+}
 
-impl<B, I: TrussedInterchange<B>, S: Syscall> FilesystemClient for ClientImplementation<B, I, S> {}
+impl<B: 'static, I: TrussedInterchange<B>, S: Syscall> FilesystemClient
+    for ClientImplementation<B, I, S>
+{
+}
 
-impl<B, I: TrussedInterchange<B>, S: Syscall> ManagementClient for ClientImplementation<B, I, S> {}
+impl<B: 'static, I: TrussedInterchange<B>, S: Syscall> ManagementClient
+    for ClientImplementation<B, I, S>
+{
+}
 
-impl<B, I: TrussedInterchange<B>, S: Syscall> UiClient for ClientImplementation<B, I, S> {}
+impl<B: 'static, I: TrussedInterchange<B>, S: Syscall> UiClient for ClientImplementation<B, I, S> {}
 
 /// Read/Write + Delete certificates
 pub trait CertificateClient: PollClient {

--- a/src/client/mechanisms.rs
+++ b/src/client/mechanisms.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 #[cfg(feature = "aes256-cbc")]
-impl<B, I: TrussedInterchange<B>, S: Syscall> Aes256Cbc for ClientImplementation<B, I, S> {}
+impl<B: 'static, I: TrussedInterchange<B>, S: Syscall> Aes256Cbc for ClientImplementation<B, I, S> {}
 
 pub trait Aes256Cbc: CryptoClient {
     fn decrypt_aes256cbc<'c>(
@@ -22,7 +22,10 @@ pub trait Aes256Cbc: CryptoClient {
 }
 
 #[cfg(feature = "chacha8-poly1305")]
-impl<B, I: TrussedInterchange<B>, S: Syscall> Chacha8Poly1305 for ClientImplementation<B, I, S> {}
+impl<B: 'static, I: TrussedInterchange<B>, S: Syscall> Chacha8Poly1305
+    for ClientImplementation<B, I, S>
+{
+}
 
 pub trait Chacha8Poly1305: CryptoClient {
     fn decrypt_chacha8poly1305<'c>(
@@ -101,7 +104,10 @@ pub trait Chacha8Poly1305: CryptoClient {
 }
 
 #[cfg(feature = "hmac-blake2s")]
-impl<B, I: TrussedInterchange<B>, S: Syscall> HmacBlake2s for ClientImplementation<B, I, S> {}
+impl<B: 'static, I: TrussedInterchange<B>, S: Syscall> HmacBlake2s
+    for ClientImplementation<B, I, S>
+{
+}
 
 pub trait HmacBlake2s: CryptoClient {
     fn hmacblake2s_derive_key(
@@ -133,7 +139,7 @@ pub trait HmacBlake2s: CryptoClient {
 }
 
 #[cfg(feature = "hmac-sha1")]
-impl<B, I: TrussedInterchange<B>, S: Syscall> HmacSha1 for ClientImplementation<B, I, S> {}
+impl<B: 'static, I: TrussedInterchange<B>, S: Syscall> HmacSha1 for ClientImplementation<B, I, S> {}
 
 pub trait HmacSha1: CryptoClient {
     fn hmacsha1_derive_key(
@@ -165,7 +171,10 @@ pub trait HmacSha1: CryptoClient {
 }
 
 #[cfg(feature = "hmac-sha256")]
-impl<B, I: TrussedInterchange<B>, S: Syscall> HmacSha256 for ClientImplementation<B, I, S> {}
+impl<B: 'static, I: TrussedInterchange<B>, S: Syscall> HmacSha256
+    for ClientImplementation<B, I, S>
+{
+}
 
 pub trait HmacSha256: CryptoClient {
     fn hmacsha256_derive_key(
@@ -197,7 +206,10 @@ pub trait HmacSha256: CryptoClient {
 }
 
 #[cfg(feature = "hmac-sha512")]
-impl<B, I: TrussedInterchange<B>, S: Syscall> HmacSha512 for ClientImplementation<B, I, S> {}
+impl<B: 'static, I: TrussedInterchange<B>, S: Syscall> HmacSha512
+    for ClientImplementation<B, I, S>
+{
+}
 
 pub trait HmacSha512: CryptoClient {
     fn hmacsha512_derive_key(
@@ -229,7 +241,7 @@ pub trait HmacSha512: CryptoClient {
 }
 
 #[cfg(feature = "ed255")]
-impl<B, I: TrussedInterchange<B>, S: Syscall> Ed255 for ClientImplementation<B, I, S> {}
+impl<B: 'static, I: TrussedInterchange<B>, S: Syscall> Ed255 for ClientImplementation<B, I, S> {}
 
 pub trait Ed255: CryptoClient {
     fn generate_ed255_private_key(
@@ -297,7 +309,7 @@ pub trait Ed255: CryptoClient {
 }
 
 #[cfg(feature = "p256")]
-impl<B, I: TrussedInterchange<B>, S: Syscall> P256 for ClientImplementation<B, I, S> {}
+impl<B: 'static, I: TrussedInterchange<B>, S: Syscall> P256 for ClientImplementation<B, I, S> {}
 
 pub trait P256: CryptoClient {
     fn generate_p256_private_key(
@@ -386,7 +398,7 @@ pub trait P256: CryptoClient {
 }
 
 #[cfg(feature = "sha256")]
-impl<B, I: TrussedInterchange<B>, S: Syscall> Sha256 for ClientImplementation<B, I, S> {}
+impl<B: 'static, I: TrussedInterchange<B>, S: Syscall> Sha256 for ClientImplementation<B, I, S> {}
 
 pub trait Sha256: CryptoClient {
     fn sha256_derive_key(
@@ -411,7 +423,7 @@ pub trait Sha256: CryptoClient {
 }
 
 #[cfg(feature = "tdes")]
-impl<B, I: TrussedInterchange<B>, S: Syscall> Tdes for ClientImplementation<B, I, S> {}
+impl<B: 'static, I: TrussedInterchange<B>, S: Syscall> Tdes for ClientImplementation<B, I, S> {}
 
 pub trait Tdes: CryptoClient {
     fn decrypt_tdes<'c>(
@@ -432,7 +444,7 @@ pub trait Tdes: CryptoClient {
 }
 
 #[cfg(feature = "totp")]
-impl<B, I: TrussedInterchange<B>, S: Syscall> Totp for ClientImplementation<B, I, S> {}
+impl<B: 'static, I: TrussedInterchange<B>, S: Syscall> Totp for ClientImplementation<B, I, S> {}
 
 pub trait Totp: CryptoClient {
     fn sign_totp(&mut self, key: KeyId, timestamp: u64) -> ClientResult<'_, reply::Sign, Self> {
@@ -446,7 +458,7 @@ pub trait Totp: CryptoClient {
 }
 
 #[cfg(feature = "x255")]
-impl<B, I: TrussedInterchange<B>, S: Syscall> X255 for ClientImplementation<B, I, S> {}
+impl<B: 'static, I: TrussedInterchange<B>, S: Syscall> X255 for ClientImplementation<B, I, S> {}
 
 pub trait X255: CryptoClient {
     fn generate_x255_secret_key(

--- a/src/client/mechanisms.rs
+++ b/src/client/mechanisms.rs
@@ -1,10 +1,7 @@
 use super::*;
 
 #[cfg(feature = "aes256-cbc")]
-impl<I: Interchange<REQUEST = Request, RESPONSE = Result<Reply>> + 'static, S: Syscall> Aes256Cbc
-    for ClientImplementation<I, S>
-{
-}
+impl<I: TrussedInterchange, S: Syscall> Aes256Cbc for ClientImplementation<I, S> {}
 
 pub trait Aes256Cbc: CryptoClient {
     fn decrypt_aes256cbc<'c>(
@@ -25,10 +22,7 @@ pub trait Aes256Cbc: CryptoClient {
 }
 
 #[cfg(feature = "chacha8-poly1305")]
-impl<I: Interchange<REQUEST = Request, RESPONSE = Result<Reply>> + 'static, S: Syscall>
-    Chacha8Poly1305 for ClientImplementation<I, S>
-{
-}
+impl<I: TrussedInterchange, S: Syscall> Chacha8Poly1305 for ClientImplementation<I, S> {}
 
 pub trait Chacha8Poly1305: CryptoClient {
     fn decrypt_chacha8poly1305<'c>(
@@ -107,10 +101,7 @@ pub trait Chacha8Poly1305: CryptoClient {
 }
 
 #[cfg(feature = "hmac-blake2s")]
-impl<I: Interchange<REQUEST = Request, RESPONSE = Result<Reply>> + 'static, S: Syscall> HmacBlake2s
-    for ClientImplementation<I, S>
-{
-}
+impl<I: TrussedInterchange, S: Syscall> HmacBlake2s for ClientImplementation<I, S> {}
 
 pub trait HmacBlake2s: CryptoClient {
     fn hmacblake2s_derive_key(
@@ -142,10 +133,7 @@ pub trait HmacBlake2s: CryptoClient {
 }
 
 #[cfg(feature = "hmac-sha1")]
-impl<I: Interchange<REQUEST = Request, RESPONSE = Result<Reply>> + 'static, S: Syscall> HmacSha1
-    for ClientImplementation<I, S>
-{
-}
+impl<I: TrussedInterchange, S: Syscall> HmacSha1 for ClientImplementation<I, S> {}
 
 pub trait HmacSha1: CryptoClient {
     fn hmacsha1_derive_key(
@@ -177,10 +165,7 @@ pub trait HmacSha1: CryptoClient {
 }
 
 #[cfg(feature = "hmac-sha256")]
-impl<I: Interchange<REQUEST = Request, RESPONSE = Result<Reply>> + 'static, S: Syscall> HmacSha256
-    for ClientImplementation<I, S>
-{
-}
+impl<I: TrussedInterchange, S: Syscall> HmacSha256 for ClientImplementation<I, S> {}
 
 pub trait HmacSha256: CryptoClient {
     fn hmacsha256_derive_key(
@@ -212,10 +197,7 @@ pub trait HmacSha256: CryptoClient {
 }
 
 #[cfg(feature = "hmac-sha512")]
-impl<I: Interchange<REQUEST = Request, RESPONSE = Result<Reply>> + 'static, S: Syscall> HmacSha512
-    for ClientImplementation<I, S>
-{
-}
+impl<I: TrussedInterchange, S: Syscall> HmacSha512 for ClientImplementation<I, S> {}
 
 pub trait HmacSha512: CryptoClient {
     fn hmacsha512_derive_key(
@@ -247,10 +229,7 @@ pub trait HmacSha512: CryptoClient {
 }
 
 #[cfg(feature = "ed255")]
-impl<I: Interchange<REQUEST = Request, RESPONSE = Result<Reply>> + 'static, S: Syscall> Ed255
-    for ClientImplementation<I, S>
-{
-}
+impl<I: TrussedInterchange, S: Syscall> Ed255 for ClientImplementation<I, S> {}
 
 pub trait Ed255: CryptoClient {
     fn generate_ed255_private_key(
@@ -318,10 +297,7 @@ pub trait Ed255: CryptoClient {
 }
 
 #[cfg(feature = "p256")]
-impl<I: Interchange<REQUEST = Request, RESPONSE = Result<Reply>> + 'static, S: Syscall> P256
-    for ClientImplementation<I, S>
-{
-}
+impl<I: TrussedInterchange, S: Syscall> P256 for ClientImplementation<I, S> {}
 
 pub trait P256: CryptoClient {
     fn generate_p256_private_key(
@@ -410,10 +386,7 @@ pub trait P256: CryptoClient {
 }
 
 #[cfg(feature = "sha256")]
-impl<I: Interchange<REQUEST = Request, RESPONSE = Result<Reply>> + 'static, S: Syscall> Sha256
-    for ClientImplementation<I, S>
-{
-}
+impl<I: TrussedInterchange, S: Syscall> Sha256 for ClientImplementation<I, S> {}
 
 pub trait Sha256: CryptoClient {
     fn sha256_derive_key(
@@ -438,10 +411,7 @@ pub trait Sha256: CryptoClient {
 }
 
 #[cfg(feature = "tdes")]
-impl<I: Interchange<REQUEST = Request, RESPONSE = Result<Reply>> + 'static, S: Syscall> Tdes
-    for ClientImplementation<I, S>
-{
-}
+impl<I: TrussedInterchange, S: Syscall> Tdes for ClientImplementation<I, S> {}
 
 pub trait Tdes: CryptoClient {
     fn decrypt_tdes<'c>(
@@ -462,10 +432,7 @@ pub trait Tdes: CryptoClient {
 }
 
 #[cfg(feature = "totp")]
-impl<I: Interchange<REQUEST = Request, RESPONSE = Result<Reply>> + 'static, S: Syscall> Totp
-    for ClientImplementation<I, S>
-{
-}
+impl<I: TrussedInterchange, S: Syscall> Totp for ClientImplementation<I, S> {}
 
 pub trait Totp: CryptoClient {
     fn sign_totp(&mut self, key: KeyId, timestamp: u64) -> ClientResult<'_, reply::Sign, Self> {
@@ -479,10 +446,7 @@ pub trait Totp: CryptoClient {
 }
 
 #[cfg(feature = "x255")]
-impl<I: Interchange<REQUEST = Request, RESPONSE = Result<Reply>> + 'static, S: Syscall> X255
-    for ClientImplementation<I, S>
-{
-}
+impl<I: TrussedInterchange, S: Syscall> X255 for ClientImplementation<I, S> {}
 
 pub trait X255: CryptoClient {
     fn generate_x255_secret_key(

--- a/src/client/mechanisms.rs
+++ b/src/client/mechanisms.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 #[cfg(feature = "aes256-cbc")]
-impl<I: TrussedInterchange, S: Syscall> Aes256Cbc for ClientImplementation<I, S> {}
+impl<B, I: TrussedInterchange<B>, S: Syscall> Aes256Cbc for ClientImplementation<B, I, S> {}
 
 pub trait Aes256Cbc: CryptoClient {
     fn decrypt_aes256cbc<'c>(
@@ -22,7 +22,7 @@ pub trait Aes256Cbc: CryptoClient {
 }
 
 #[cfg(feature = "chacha8-poly1305")]
-impl<I: TrussedInterchange, S: Syscall> Chacha8Poly1305 for ClientImplementation<I, S> {}
+impl<B, I: TrussedInterchange<B>, S: Syscall> Chacha8Poly1305 for ClientImplementation<B, I, S> {}
 
 pub trait Chacha8Poly1305: CryptoClient {
     fn decrypt_chacha8poly1305<'c>(
@@ -101,7 +101,7 @@ pub trait Chacha8Poly1305: CryptoClient {
 }
 
 #[cfg(feature = "hmac-blake2s")]
-impl<I: TrussedInterchange, S: Syscall> HmacBlake2s for ClientImplementation<I, S> {}
+impl<B, I: TrussedInterchange<B>, S: Syscall> HmacBlake2s for ClientImplementation<B, I, S> {}
 
 pub trait HmacBlake2s: CryptoClient {
     fn hmacblake2s_derive_key(
@@ -133,7 +133,7 @@ pub trait HmacBlake2s: CryptoClient {
 }
 
 #[cfg(feature = "hmac-sha1")]
-impl<I: TrussedInterchange, S: Syscall> HmacSha1 for ClientImplementation<I, S> {}
+impl<B, I: TrussedInterchange<B>, S: Syscall> HmacSha1 for ClientImplementation<B, I, S> {}
 
 pub trait HmacSha1: CryptoClient {
     fn hmacsha1_derive_key(
@@ -165,7 +165,7 @@ pub trait HmacSha1: CryptoClient {
 }
 
 #[cfg(feature = "hmac-sha256")]
-impl<I: TrussedInterchange, S: Syscall> HmacSha256 for ClientImplementation<I, S> {}
+impl<B, I: TrussedInterchange<B>, S: Syscall> HmacSha256 for ClientImplementation<B, I, S> {}
 
 pub trait HmacSha256: CryptoClient {
     fn hmacsha256_derive_key(
@@ -197,7 +197,7 @@ pub trait HmacSha256: CryptoClient {
 }
 
 #[cfg(feature = "hmac-sha512")]
-impl<I: TrussedInterchange, S: Syscall> HmacSha512 for ClientImplementation<I, S> {}
+impl<B, I: TrussedInterchange<B>, S: Syscall> HmacSha512 for ClientImplementation<B, I, S> {}
 
 pub trait HmacSha512: CryptoClient {
     fn hmacsha512_derive_key(
@@ -229,7 +229,7 @@ pub trait HmacSha512: CryptoClient {
 }
 
 #[cfg(feature = "ed255")]
-impl<I: TrussedInterchange, S: Syscall> Ed255 for ClientImplementation<I, S> {}
+impl<B, I: TrussedInterchange<B>, S: Syscall> Ed255 for ClientImplementation<B, I, S> {}
 
 pub trait Ed255: CryptoClient {
     fn generate_ed255_private_key(
@@ -297,7 +297,7 @@ pub trait Ed255: CryptoClient {
 }
 
 #[cfg(feature = "p256")]
-impl<I: TrussedInterchange, S: Syscall> P256 for ClientImplementation<I, S> {}
+impl<B, I: TrussedInterchange<B>, S: Syscall> P256 for ClientImplementation<B, I, S> {}
 
 pub trait P256: CryptoClient {
     fn generate_p256_private_key(
@@ -386,7 +386,7 @@ pub trait P256: CryptoClient {
 }
 
 #[cfg(feature = "sha256")]
-impl<I: TrussedInterchange, S: Syscall> Sha256 for ClientImplementation<I, S> {}
+impl<B, I: TrussedInterchange<B>, S: Syscall> Sha256 for ClientImplementation<B, I, S> {}
 
 pub trait Sha256: CryptoClient {
     fn sha256_derive_key(
@@ -411,7 +411,7 @@ pub trait Sha256: CryptoClient {
 }
 
 #[cfg(feature = "tdes")]
-impl<I: TrussedInterchange, S: Syscall> Tdes for ClientImplementation<I, S> {}
+impl<B, I: TrussedInterchange<B>, S: Syscall> Tdes for ClientImplementation<B, I, S> {}
 
 pub trait Tdes: CryptoClient {
     fn decrypt_tdes<'c>(
@@ -432,7 +432,7 @@ pub trait Tdes: CryptoClient {
 }
 
 #[cfg(feature = "totp")]
-impl<I: TrussedInterchange, S: Syscall> Totp for ClientImplementation<I, S> {}
+impl<B, I: TrussedInterchange<B>, S: Syscall> Totp for ClientImplementation<B, I, S> {}
 
 pub trait Totp: CryptoClient {
     fn sign_totp(&mut self, key: KeyId, timestamp: u64) -> ClientResult<'_, reply::Sign, Self> {
@@ -446,7 +446,7 @@ pub trait Totp: CryptoClient {
 }
 
 #[cfg(feature = "x255")]
-impl<I: TrussedInterchange, S: Syscall> X255 for ClientImplementation<I, S> {}
+impl<B, I: TrussedInterchange<B>, S: Syscall> X255 for ClientImplementation<B, I, S> {}
 
 pub trait X255: CryptoClient {
     fn generate_x255_secret_key(

--- a/src/client/mechanisms.rs
+++ b/src/client/mechanisms.rs
@@ -1,7 +1,10 @@
 use super::*;
 
 #[cfg(feature = "aes256-cbc")]
-impl<S: Syscall> Aes256Cbc for ClientImplementation<S> {}
+impl<I: Interchange<REQUEST = Request, RESPONSE = Result<Reply>> + 'static, S: Syscall> Aes256Cbc
+    for ClientImplementation<I, S>
+{
+}
 
 pub trait Aes256Cbc: CryptoClient {
     fn decrypt_aes256cbc<'c>(
@@ -22,7 +25,10 @@ pub trait Aes256Cbc: CryptoClient {
 }
 
 #[cfg(feature = "chacha8-poly1305")]
-impl<S: Syscall> Chacha8Poly1305 for ClientImplementation<S> {}
+impl<I: Interchange<REQUEST = Request, RESPONSE = Result<Reply>> + 'static, S: Syscall>
+    Chacha8Poly1305 for ClientImplementation<I, S>
+{
+}
 
 pub trait Chacha8Poly1305: CryptoClient {
     fn decrypt_chacha8poly1305<'c>(
@@ -101,7 +107,10 @@ pub trait Chacha8Poly1305: CryptoClient {
 }
 
 #[cfg(feature = "hmac-blake2s")]
-impl<S: Syscall> HmacBlake2s for ClientImplementation<S> {}
+impl<I: Interchange<REQUEST = Request, RESPONSE = Result<Reply>> + 'static, S: Syscall> HmacBlake2s
+    for ClientImplementation<I, S>
+{
+}
 
 pub trait HmacBlake2s: CryptoClient {
     fn hmacblake2s_derive_key(
@@ -133,7 +142,10 @@ pub trait HmacBlake2s: CryptoClient {
 }
 
 #[cfg(feature = "hmac-sha1")]
-impl<S: Syscall> HmacSha1 for ClientImplementation<S> {}
+impl<I: Interchange<REQUEST = Request, RESPONSE = Result<Reply>> + 'static, S: Syscall> HmacSha1
+    for ClientImplementation<I, S>
+{
+}
 
 pub trait HmacSha1: CryptoClient {
     fn hmacsha1_derive_key(
@@ -165,7 +177,10 @@ pub trait HmacSha1: CryptoClient {
 }
 
 #[cfg(feature = "hmac-sha256")]
-impl<S: Syscall> HmacSha256 for ClientImplementation<S> {}
+impl<I: Interchange<REQUEST = Request, RESPONSE = Result<Reply>> + 'static, S: Syscall> HmacSha256
+    for ClientImplementation<I, S>
+{
+}
 
 pub trait HmacSha256: CryptoClient {
     fn hmacsha256_derive_key(
@@ -197,7 +212,10 @@ pub trait HmacSha256: CryptoClient {
 }
 
 #[cfg(feature = "hmac-sha512")]
-impl<S: Syscall> HmacSha512 for ClientImplementation<S> {}
+impl<I: Interchange<REQUEST = Request, RESPONSE = Result<Reply>> + 'static, S: Syscall> HmacSha512
+    for ClientImplementation<I, S>
+{
+}
 
 pub trait HmacSha512: CryptoClient {
     fn hmacsha512_derive_key(
@@ -229,7 +247,10 @@ pub trait HmacSha512: CryptoClient {
 }
 
 #[cfg(feature = "ed255")]
-impl<S: Syscall> Ed255 for ClientImplementation<S> {}
+impl<I: Interchange<REQUEST = Request, RESPONSE = Result<Reply>> + 'static, S: Syscall> Ed255
+    for ClientImplementation<I, S>
+{
+}
 
 pub trait Ed255: CryptoClient {
     fn generate_ed255_private_key(
@@ -297,7 +318,10 @@ pub trait Ed255: CryptoClient {
 }
 
 #[cfg(feature = "p256")]
-impl<S: Syscall> P256 for ClientImplementation<S> {}
+impl<I: Interchange<REQUEST = Request, RESPONSE = Result<Reply>> + 'static, S: Syscall> P256
+    for ClientImplementation<I, S>
+{
+}
 
 pub trait P256: CryptoClient {
     fn generate_p256_private_key(
@@ -386,7 +410,10 @@ pub trait P256: CryptoClient {
 }
 
 #[cfg(feature = "sha256")]
-impl<S: Syscall> Sha256 for ClientImplementation<S> {}
+impl<I: Interchange<REQUEST = Request, RESPONSE = Result<Reply>> + 'static, S: Syscall> Sha256
+    for ClientImplementation<I, S>
+{
+}
 
 pub trait Sha256: CryptoClient {
     fn sha256_derive_key(
@@ -411,7 +438,10 @@ pub trait Sha256: CryptoClient {
 }
 
 #[cfg(feature = "tdes")]
-impl<S: Syscall> Tdes for ClientImplementation<S> {}
+impl<I: Interchange<REQUEST = Request, RESPONSE = Result<Reply>> + 'static, S: Syscall> Tdes
+    for ClientImplementation<I, S>
+{
+}
 
 pub trait Tdes: CryptoClient {
     fn decrypt_tdes<'c>(
@@ -432,7 +462,10 @@ pub trait Tdes: CryptoClient {
 }
 
 #[cfg(feature = "totp")]
-impl<S: Syscall> Totp for ClientImplementation<S> {}
+impl<I: Interchange<REQUEST = Request, RESPONSE = Result<Reply>> + 'static, S: Syscall> Totp
+    for ClientImplementation<I, S>
+{
+}
 
 pub trait Totp: CryptoClient {
     fn sign_totp(&mut self, key: KeyId, timestamp: u64) -> ClientResult<'_, reply::Sign, Self> {
@@ -446,7 +479,10 @@ pub trait Totp: CryptoClient {
 }
 
 #[cfg(feature = "x255")]
-impl<S: Syscall> X255 for ClientImplementation<S> {}
+impl<I: Interchange<REQUEST = Request, RESPONSE = Result<Reply>> + 'static, S: Syscall> X255
+    for ClientImplementation<I, S>
+{
+}
 
 pub trait X255: CryptoClient {
     fn generate_x255_secret_key(

--- a/src/mechanisms/hmacsha256.rs
+++ b/src/mechanisms/hmacsha256.rs
@@ -18,7 +18,10 @@ impl DeriveKey for super::HmacSha256 {
         if !matches!(key.kind, key::Kind::Symmetric(..) | key::Kind::Shared(..)) {
             // We have to disable this check for compatibility with fido-authenticator, see:
             // https://github.com/solokeys/fido-authenticator/issues/21
-            warn!("derive_key for hmacsha256 called with invalid key kind ({:?})", key.kind);
+            warn!(
+                "derive_key for hmacsha256 called with invalid key kind ({:?})",
+                key.kind
+            );
         }
         let shared_secret = key.material;
 

--- a/src/pipe.rs
+++ b/src/pipe.rs
@@ -3,7 +3,7 @@ use interchange::Responder;
 
 use crate::api::{Reply, Request};
 use crate::error::Error;
-use crate::types::ClientId;
+use crate::types::ClientContext;
 
 cfg_if::cfg_if! {
 
@@ -72,7 +72,7 @@ pub struct ServiceEndpoint {
     pub interchange: Responder<TrussedInterchange>,
     // service (trusted) has this, not client (untrusted)
     // used among other things to namespace cryptographic material
-    pub client_id: ClientId,
+    pub client_ctx: ClientContext,
 }
 
 // pub type ClientEndpoint = Requester<TrussedInterchange>;

--- a/src/pipe.rs
+++ b/src/pipe.rs
@@ -6,59 +6,38 @@ use crate::error::Error;
 use crate::types::ClientContext;
 
 cfg_if::cfg_if! {
-
     if #[cfg(feature = "clients-12")] {
-        interchange::interchange! {
-            TrussedInterchange: (Request, Result<Reply, Error>, 12)
-        }
+        pub const CLIENT_COUNT: usize = 12;
     } else if #[cfg(feature = "clients-11")] {
-        interchange::interchange! {
-            TrussedInterchange: (Request, Result<Reply, Error>, 11)
-        }
+        pub const CLIENT_COUNT: usize = 11;
     } else if #[cfg(feature = "clients-10")] {
-        interchange::interchange! {
-            TrussedInterchange: (Request, Result<Reply, Error>, 10)
-        }
+        pub const CLIENT_COUNT: usize = 10;
     } else if #[cfg(feature = "clients-9")] {
-        interchange::interchange! {
-            TrussedInterchange: (Request, Result<Reply, Error>, 9)
-        }
+        pub const CLIENT_COUNT: usize = 9;
     } else if #[cfg(feature = "clients-8")] {
-        interchange::interchange! {
-            TrussedInterchange: (Request, Result<Reply, Error>, 8)
-        }
+        pub const CLIENT_COUNT: usize = 8;
     } else if #[cfg(feature = "clients-7")] {
-        interchange::interchange! {
-            TrussedInterchange: (Request, Result<Reply, Error>, 7)
-        }
+        pub const CLIENT_COUNT: usize = 7;
     } else if #[cfg(feature = "clients-6")] {
-        interchange::interchange! {
-            TrussedInterchange: (Request, Result<Reply, Error>, 6)
-        }
+        pub const CLIENT_COUNT: usize = 6;
     } else if #[cfg(feature = "clients-5")] {
-        interchange::interchange! {
-            TrussedInterchange: (Request, Result<Reply, Error>, 5)
-        }
+        pub const CLIENT_COUNT: usize = 5;
     } else if #[cfg(feature = "clients-4")] {
-        interchange::interchange! {
-            TrussedInterchange: (Request, Result<Reply, Error>, 4)
-        }
+        pub const CLIENT_COUNT: usize = 4;
     } else if #[cfg(feature = "clients-3")] {
-        interchange::interchange! {
-            TrussedInterchange: (Request, Result<Reply, Error>, 3)
-        }
+        pub const CLIENT_COUNT: usize = 3;
     } else if #[cfg(feature = "clients-2")] {
-        interchange::interchange! {
-            TrussedInterchange: (Request, Result<Reply, Error>, 2)
-        }
+        pub const CLIENT_COUNT: usize = 2;
     } else if #[cfg(feature = "clients-1")] {
-        interchange::interchange! {
-            TrussedInterchange: (Request, Result<Reply, Error>, 1)
-        }
+        pub const CLIENT_COUNT: usize = 1;
+    } else {
+        compile_error!("missing clients feature");
     }
 }
 
-// pub use interchange::TrussedInterchange;
+interchange::interchange! {
+    TrussedInterchange: (Request, Result<Reply, Error>, CLIENT_COUNT)
+}
 
 // TODO: The request pipe should block if there is an unhandled
 // previous request/reply. As a side effect, the service should always

--- a/src/pipe.rs
+++ b/src/pipe.rs
@@ -8,12 +8,12 @@ use crate::{
     types::ClientContext,
 };
 
-pub trait TrussedInterchange<B>:
+pub trait TrussedInterchange<B: 'static>:
     Interchange<REQUEST = Request<B>, RESPONSE = Result<Reply>> + 'static
 {
 }
 
-impl<B, I: Interchange<REQUEST = Request<B>, RESPONSE = Result<Reply>> + 'static>
+impl<B: 'static, I: Interchange<REQUEST = Request<B>, RESPONSE = Result<Reply>> + 'static>
     TrussedInterchange<B> for I
 {
 }
@@ -56,7 +56,7 @@ cfg_if::cfg_if! {
 // https://xenomai.org/documentation/xenomai-2.4/html/api/group__native__queue.html
 // https://doc.micrium.com/display/osiiidoc/Using+Message+Queues
 
-pub struct ServiceEndpoint<B, I: Interchange + 'static> {
+pub struct ServiceEndpoint<B: 'static, I: Interchange + 'static> {
     pub interchange: Responder<I>,
     // service (trusted) has this, not client (untrusted)
     // used among other things to namespace cryptographic material

--- a/src/pipe.rs
+++ b/src/pipe.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::transmute_ptr_to_ptr)]
-use interchange::Responder;
+
+use interchange::{Interchange, Responder};
 
 use crate::api::{Reply, Request};
 use crate::error::Error;
@@ -47,8 +48,8 @@ interchange::interchange! {
 // https://xenomai.org/documentation/xenomai-2.4/html/api/group__native__queue.html
 // https://doc.micrium.com/display/osiiidoc/Using+Message+Queues
 
-pub struct ServiceEndpoint {
-    pub interchange: Responder<TrussedInterchange>,
+pub struct ServiceEndpoint<I: Interchange + 'static> {
+    pub interchange: Responder<I>,
     // service (trusted) has this, not client (untrusted)
     // used among other things to namespace cryptographic material
     pub client_ctx: ClientContext,

--- a/src/pipe.rs
+++ b/src/pipe.rs
@@ -2,8 +2,6 @@
 
 use interchange::{Interchange, Responder};
 
-use crate::api::{Reply, Request};
-use crate::error::Error;
 use crate::types::ClientContext;
 
 cfg_if::cfg_if! {
@@ -34,10 +32,6 @@ cfg_if::cfg_if! {
     } else {
         compile_error!("missing clients feature");
     }
-}
-
-interchange::interchange! {
-    TrussedInterchange: (Request, Result<Reply, Error>, CLIENT_COUNT)
 }
 
 // TODO: The request pipe should block if there is an unhandled

--- a/src/pipe.rs
+++ b/src/pipe.rs
@@ -2,7 +2,21 @@
 
 use interchange::{Interchange, Responder};
 
-use crate::types::ClientContext;
+use crate::{
+    api::{Reply, Request},
+    error::Result,
+    types::ClientContext,
+};
+
+pub trait TrussedInterchange:
+    Interchange<REQUEST = Request, RESPONSE = Result<Reply>> + 'static
+{
+}
+
+impl<I: Interchange<REQUEST = Request, RESPONSE = Result<Reply>> + 'static> TrussedInterchange
+    for I
+{
+}
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "clients-12")] {

--- a/src/pipe.rs
+++ b/src/pipe.rs
@@ -8,13 +8,13 @@ use crate::{
     types::ClientContext,
 };
 
-pub trait TrussedInterchange:
-    Interchange<REQUEST = Request, RESPONSE = Result<Reply>> + 'static
+pub trait TrussedInterchange<B>:
+    Interchange<REQUEST = Request<B>, RESPONSE = Result<Reply>> + 'static
 {
 }
 
-impl<I: Interchange<REQUEST = Request, RESPONSE = Result<Reply>> + 'static> TrussedInterchange
-    for I
+impl<B, I: Interchange<REQUEST = Request<B>, RESPONSE = Result<Reply>> + 'static>
+    TrussedInterchange<B> for I
 {
 }
 
@@ -56,11 +56,11 @@ cfg_if::cfg_if! {
 // https://xenomai.org/documentation/xenomai-2.4/html/api/group__native__queue.html
 // https://doc.micrium.com/display/osiiidoc/Using+Message+Queues
 
-pub struct ServiceEndpoint<I: Interchange + 'static> {
+pub struct ServiceEndpoint<B, I: Interchange + 'static> {
     pub interchange: Responder<I>,
     // service (trusted) has this, not client (untrusted)
     // used among other things to namespace cryptographic material
-    pub client_ctx: ClientContext,
+    pub client_ctx: ClientContext<B>,
 }
 
 // pub type ClientEndpoint = Requester<TrussedInterchange>;

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -7,9 +7,10 @@
 //! TODO: Currently, `Platform::R` lacks the `CryptoRng` bound.
 
 // pub use rand_core::{CryptoRng, RngCore};
+use crate::api::{Reply, Request};
+use crate::error::Error;
 pub use crate::store::Store;
-pub use crate::types::consent;
-pub use crate::types::{reboot, ui};
+pub use crate::types::{consent, reboot, ui, ClientContext, ServiceBackends};
 pub use rand_core::{CryptoRng, RngCore};
 
 pub trait UserInterface {
@@ -63,54 +64,66 @@ pub unsafe trait Platform {
     fn rng(&mut self) -> &mut Self::R;
     fn store(&self) -> Self::S;
     fn user_interface(&mut self) -> &mut Self::UI;
+    fn platform_reply_to(
+        &mut self,
+        backend_id: ServiceBackends,
+        client_id: &mut ClientContext,
+        request: &Request,
+    ) -> Result<Reply, Error>;
 }
 
 #[macro_export]
-macro_rules! platform {
-    (
+macro_rules! platform { (
     $PlatformName:ident,
     R: $Rng:ty,
     S: $Store:ty,
     UI: $UserInterface:ty,
+    $($BackendID:pat, $BackendName:ident, $BackendType:ty),*
 ) => {
-        /// Platform struct implemented `trussed::Platform`, generated
-        /// by a Trussed-supplied macro at call site, using the platform-specific
-        /// implementations of its components.
-        pub struct $PlatformName {
-            rng: $Rng,
-            store: $Store,
-            user_interface: $UserInterface,
+
+    /// Platform struct implemented `trussed::Platform`, generated
+    /// by a Trussed-supplied macro at call site, using the platform-specific
+    /// implementations of its components.
+    pub struct $PlatformName {
+        rng: $Rng,
+        store: $Store,
+        user_interface: $UserInterface,
+        $($BackendName: $BackendType),*
+    }
+
+    impl $PlatformName {
+        pub fn new(rng: $Rng, store: $Store, user_interface: $UserInterface, $($BackendName: $BackendType),*) -> Self {
+            Self { rng, store, user_interface, $($BackendName),* }
+        }
+    }
+
+    unsafe impl $crate::platform::Platform for $PlatformName {
+        type R = $Rng;
+        type S = $Store;
+        type UI = $UserInterface;
+
+        fn user_interface(&mut self) -> &mut Self::UI {
+            &mut self.user_interface
         }
 
-        impl $PlatformName {
-            pub fn new(rng: $Rng, store: $Store, user_interface: $UserInterface) -> Self {
-                Self {
-                    rng,
-                    store,
-                    user_interface,
-                }
-            }
+        fn rng(&mut self) -> &mut Self::R {
+            &mut self.rng
         }
 
-        unsafe impl $crate::platform::Platform for $PlatformName {
-            type R = $Rng;
-            type S = $Store;
-            type UI = $UserInterface;
-
-            fn user_interface(&mut self) -> &mut Self::UI {
-                &mut self.user_interface
-            }
-
-            fn rng(&mut self) -> &mut Self::R {
-                &mut self.rng
-            }
-
-            fn store(&self) -> Self::S {
-                self.store
-            }
+        fn store(&self) -> Self::S {
+            self.store
         }
-    };
-}
+
+        #[allow(unused)]
+        fn platform_reply_to(&mut self, backend_id: $crate::types::ServiceBackends, client_id: &mut $crate::types::ClientContext, request: &$crate::api::Request) -> Result<$crate::api::Reply, $crate::error::Error> {
+            $(if let $BackendID = backend_id {
+                let b: &mut dyn $crate::types::ServiceBackend = &mut self.$BackendName;
+                return b.reply_to(client_id, request);
+            } );*
+            return Err($crate::error::Error::RequestNotAvailable);
+        }
+    }
+}}
 
 /// Trussed client will call this method when making a Trussed request.
 /// This is intended to trigger a secure context on the platform.

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -59,7 +59,7 @@ pub trait UserInterface {
 // replacing generic parameters with associated types
 // and a macro.
 pub unsafe trait Platform {
-    type B: Clone + Debug + PartialEq;
+    type B: 'static + Debug + PartialEq;
     type I: Interchange<REQUEST = Request<Self::B>, RESPONSE = Result<Reply>> + 'static;
     // temporarily remove CryptoRng bound until HALs come along
     type R: CryptoRng + RngCore;
@@ -69,7 +69,7 @@ pub unsafe trait Platform {
     fn rng(&mut self) -> &mut Self::R;
     fn store(&self) -> Self::S;
     fn user_interface(&mut self) -> &mut Self::UI;
-    fn backend(&mut self, _backend: Self::B) -> Option<&mut dyn ServiceBackend<Self::B>> {
+    fn backend(&mut self, _backend: &Self::B) -> Option<&mut dyn ServiceBackend<Self::B>> {
         None
     }
 }
@@ -119,8 +119,8 @@ macro_rules! platform { (
             self.store
         }
 
-        fn backend(&mut self, backend: Self::B) -> Option<&mut dyn $crate::types::ServiceBackend<Self::B>> {
-            match backend{
+        fn backend(&mut self, backend: &Self::B) -> Option<&mut dyn $crate::types::ServiceBackend<Self::B>> {
+            match backend {
                 $($BackendID => Some(&mut self.$BackendName), );*
                 _ => None,
             }

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -75,6 +75,7 @@ pub unsafe trait Platform {
 #[macro_export]
 macro_rules! platform { (
     $PlatformName:ident,
+    I: $Interchange:ty,
     R: $Rng:ty,
     S: $Store:ty,
     UI: $UserInterface:ty,
@@ -98,7 +99,7 @@ macro_rules! platform { (
     }
 
     unsafe impl $crate::platform::Platform for $PlatformName {
-        type I = $crate::pipe::TrussedInterchange;
+        type I = $Interchange;
         type R = $Rng;
         type S = $Store;
         type UI = $UserInterface;

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -7,9 +7,9 @@
 //! TODO: Currently, `Platform::R` lacks the `CryptoRng` bound.
 
 // pub use rand_core::{CryptoRng, RngCore};
-use core::fmt::Debug;
 use crate::api::{Reply, Request};
 use crate::error::Result;
+use core::fmt::Debug;
 use interchange::Interchange;
 
 pub use crate::store::Store;
@@ -69,64 +69,57 @@ pub unsafe trait Platform {
     fn rng(&mut self) -> &mut Self::R;
     fn store(&self) -> Self::S;
     fn user_interface(&mut self) -> &mut Self::UI;
-    fn backend(&mut self, _backend: &Self::B) -> Option<&mut dyn ServiceBackend<Self::B>> {
-        None
-    }
 }
 
 #[macro_export]
-macro_rules! platform { (
+macro_rules! platform {
+    (
     $PlatformName:ident,
     I: $Interchange:ty,
     R: $Rng:ty,
     S: $Store:ty,
     UI: $UserInterface:ty,
-    $($BackendID:pat, $BackendName:ident, $BackendType:ty),*
 ) => {
-
-    /// Platform struct implemented `trussed::Platform`, generated
-    /// by a Trussed-supplied macro at call site, using the platform-specific
-    /// implementations of its components.
-    pub struct $PlatformName {
-        rng: $Rng,
-        store: $Store,
-        user_interface: $UserInterface,
-        $($BackendName: $BackendType),*
-    }
-
-    impl $PlatformName {
-        pub fn new(rng: $Rng, store: $Store, user_interface: $UserInterface, $($BackendName: $BackendType),*) -> Self {
-            Self { rng, store, user_interface, $($BackendName),* }
-        }
-    }
-
-    unsafe impl $crate::platform::Platform for $PlatformName {
-        type B = ();
-        type I = $Interchange;
-        type R = $Rng;
-        type S = $Store;
-        type UI = $UserInterface;
-
-        fn user_interface(&mut self) -> &mut Self::UI {
-            &mut self.user_interface
+        /// Platform struct implemented `trussed::Platform`, generated
+        /// by a Trussed-supplied macro at call site, using the platform-specific
+        /// implementations of its components.
+        pub struct $PlatformName {
+            rng: $Rng,
+            store: $Store,
+            user_interface: $UserInterface,
         }
 
-        fn rng(&mut self) -> &mut Self::R {
-            &mut self.rng
-        }
-
-        fn store(&self) -> Self::S {
-            self.store
-        }
-
-        fn backend(&mut self, backend: &Self::B) -> Option<&mut dyn $crate::types::ServiceBackend<Self::B>> {
-            match backend {
-                $($BackendID => Some(&mut self.$BackendName), );*
-                _ => None,
+        impl $PlatformName {
+            pub fn new(rng: $Rng, store: $Store, user_interface: $UserInterface) -> Self {
+                Self {
+                    rng,
+                    store,
+                    user_interface,
+                }
             }
         }
-    }
-}}
+
+        unsafe impl $crate::platform::Platform for $PlatformName {
+            type B = ();
+            type I = $Interchange;
+            type R = $Rng;
+            type S = $Store;
+            type UI = $UserInterface;
+
+            fn user_interface(&mut self) -> &mut Self::UI {
+                &mut self.user_interface
+            }
+
+            fn rng(&mut self) -> &mut Self::R {
+                &mut self.rng
+            }
+
+            fn store(&self) -> Self::S {
+                self.store
+            }
+        }
+    };
+}
 
 /// Trussed client will call this method when making a Trussed request.
 /// This is intended to trigger a secure context on the platform.

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -7,6 +7,10 @@
 //! TODO: Currently, `Platform::R` lacks the `CryptoRng` bound.
 
 // pub use rand_core::{CryptoRng, RngCore};
+use crate::api::{Reply, Request};
+use crate::error::Result;
+use interchange::Interchange;
+
 pub use crate::store::Store;
 pub use crate::types::{consent, reboot, ui, ClientContext, ServiceBackend, ServiceBackends};
 pub use rand_core::{CryptoRng, RngCore};
@@ -55,6 +59,7 @@ pub trait UserInterface {
 // and a macro.
 pub unsafe trait Platform {
     // temporarily remove CryptoRng bound until HALs come along
+    type I: Interchange<REQUEST = Request, RESPONSE = Result<Reply>> + 'static;
     type R: CryptoRng + RngCore;
     type S: Store;
     type UI: UserInterface;
@@ -93,6 +98,7 @@ macro_rules! platform { (
     }
 
     unsafe impl $crate::platform::Platform for $PlatformName {
+        type I = $crate::pipe::TrussedInterchange;
         type R = $Rng;
         type S = $Store;
         type UI = $UserInterface;

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -7,12 +7,13 @@
 //! TODO: Currently, `Platform::R` lacks the `CryptoRng` bound.
 
 // pub use rand_core::{CryptoRng, RngCore};
+use core::fmt::Debug;
 use crate::api::{Reply, Request};
 use crate::error::Result;
 use interchange::Interchange;
 
 pub use crate::store::Store;
-pub use crate::types::{consent, reboot, ui, ClientContext, ServiceBackend, ServiceBackends};
+pub use crate::types::{consent, reboot, ui, ClientContext, ServiceBackend};
 pub use rand_core::{CryptoRng, RngCore};
 
 pub trait UserInterface {
@@ -58,8 +59,9 @@ pub trait UserInterface {
 // replacing generic parameters with associated types
 // and a macro.
 pub unsafe trait Platform {
+    type B: Clone + Debug + PartialEq;
+    type I: Interchange<REQUEST = Request<Self::B>, RESPONSE = Result<Reply>> + 'static;
     // temporarily remove CryptoRng bound until HALs come along
-    type I: Interchange<REQUEST = Request, RESPONSE = Result<Reply>> + 'static;
     type R: CryptoRng + RngCore;
     type S: Store;
     type UI: UserInterface;
@@ -67,7 +69,7 @@ pub unsafe trait Platform {
     fn rng(&mut self) -> &mut Self::R;
     fn store(&self) -> Self::S;
     fn user_interface(&mut self) -> &mut Self::UI;
-    fn backend(&mut self, _backend_id: ServiceBackends) -> Option<&mut dyn ServiceBackend> {
+    fn backend(&mut self, _backend: Self::B) -> Option<&mut dyn ServiceBackend<Self::B>> {
         None
     }
 }
@@ -99,6 +101,7 @@ macro_rules! platform { (
     }
 
     unsafe impl $crate::platform::Platform for $PlatformName {
+        type B = ();
         type I = $Interchange;
         type R = $Rng;
         type S = $Store;
@@ -116,8 +119,8 @@ macro_rules! platform { (
             self.store
         }
 
-        fn backend(&mut self, backend_id: $crate::types::ServiceBackends) -> Option<&mut dyn $crate::types::ServiceBackend> {
-            match backend_id {
+        fn backend(&mut self, backend: Self::B) -> Option<&mut dyn $crate::types::ServiceBackend<Self::B>> {
+            match backend{
                 $($BackendID => Some(&mut self.$BackendName), );*
                 _ => None,
             }

--- a/src/service.rs
+++ b/src/service.rs
@@ -572,6 +572,12 @@ impl<P: Platform> ServiceResources<P> {
                     .map(|id| Reply::WriteCertificate(reply::WriteCertificate { id } ))
             }
 
+            Request::SetServiceBackends(request) => {
+                client_ctx.backends.clear();
+                client_ctx.backends.extend_from_slice(&request.backends);
+                Ok(Reply::SetServiceBackends(reply::SetServiceBackends {}))
+            }
+
             // _ => {
             //     // #[cfg(test)]
             //     // println!("todo: {:?} request!", &request);

--- a/src/service.rs
+++ b/src/service.rs
@@ -328,11 +328,11 @@ impl<P: Platform> ServiceResources<P> {
             Request::ReadDirFirst(request) => {
                 let maybe_entry = match filestore.read_dir_first(&request.dir, request.location, request.not_before_filename.as_ref())? {
                     Some((entry, read_dir_state)) => {
-                        self.read_dir_state = Some(read_dir_state);
+                        client_id.read_dir_state = Some(read_dir_state);
                         Some(entry)
                     }
                     None => {
-                        self.read_dir_state = None;
+                        client_id.read_dir_state = None;
                         None
 
                     }
@@ -342,18 +342,18 @@ impl<P: Platform> ServiceResources<P> {
 
             Request::ReadDirNext(_request) => {
                 // ensure next call has nothing to work with, unless we store state again
-                let read_dir_state = self.read_dir_state.take();
+                let read_dir_state = client_id.read_dir_state.take();
 
                 let maybe_entry = match read_dir_state {
                     None => None,
                     Some(state) => {
                         match filestore.read_dir_next(state)? {
                             Some((entry, read_dir_state)) => {
-                                self.read_dir_state = Some(read_dir_state);
+                                client_id.read_dir_state = Some(read_dir_state);
                                 Some(entry)
                             }
                             None => {
-                                self.read_dir_state = None;
+                                client_id.read_dir_state = None;
                                 None
                             }
                         }
@@ -366,11 +366,11 @@ impl<P: Platform> ServiceResources<P> {
             Request::ReadDirFilesFirst(request) => {
                 let maybe_data = match filestore.read_dir_files_first(&request.dir, request.location, request.user_attribute.clone())? {
                     Some((data, state)) => {
-                        self.read_dir_files_state = Some(state);
+                        client_id.read_dir_files_state = Some(state);
                         data
                     }
                     None => {
-                        self.read_dir_files_state = None;
+                        client_id.read_dir_files_state = None;
                         None
                     }
                 };
@@ -378,18 +378,18 @@ impl<P: Platform> ServiceResources<P> {
             }
 
             Request::ReadDirFilesNext(_request) => {
-                let read_dir_files_state = self.read_dir_files_state.take();
+                let read_dir_files_state = client_id.read_dir_files_state.take();
 
                 let maybe_data = match read_dir_files_state {
                     None => None,
                     Some(state) => {
                         match filestore.read_dir_files_next(state)? {
                             Some((data, state)) => {
-                                self.read_dir_files_state = Some(state);
+                                client_id.read_dir_files_state = Some(state);
                                 data
                             }
                             None => {
-                                self.read_dir_files_state = None;
+                                client_id.read_dir_files_state = None;
                                 None
                             }
                         }

--- a/src/service.rs
+++ b/src/service.rs
@@ -573,8 +573,14 @@ impl<P: Platform> ServiceResources<P> {
             }
 
             Request::SetServiceBackends(request) => {
+                /* as long as we don't do backend selection per syscall,
+                   reject clients that want to drop the software backend;
+		   otherwise they will never be able to switch again! */
+                if !request.backends.contains(&ServiceBackends::Software) {
+                    return Err(Error::InternalError);
+                }
                 client_ctx.backends.clear();
-                client_ctx.backends.extend_from_slice(&request.backends);
+                client_ctx.backends.extend_from_slice(&request.backends).unwrap();
                 Ok(Reply::SetServiceBackends(reply::SetServiceBackends {}))
             }
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -84,7 +84,7 @@ impl<P: Platform> ServiceResources<P> {
     #[inline(never)]
     pub fn reply_to(
         &mut self,
-        client_id: &mut ClientContext,
+        client_ctx: &mut ClientContext,
         request: &Request,
     ) -> Result<Reply, Error> {
         // TODO: what we want to do here is map an enum to a generic type
@@ -94,7 +94,7 @@ impl<P: Platform> ServiceResources<P> {
 
         // prepare keystore, bound to client_id, for cryptographic calls
         let mut keystore: ClientKeystore<P::S> = ClientKeystore::new(
-            client_id.path.clone(),
+            client_ctx.path.clone(),
             self.rng().map_err(|_| Error::EntropyMalfunction)?,
             full_store,
         );
@@ -102,7 +102,7 @@ impl<P: Platform> ServiceResources<P> {
 
         // prepare certstore, bound to client_id, for cert calls
         let mut certstore: ClientCertstore<P::S> = ClientCertstore::new(
-            client_id.path.clone(),
+            client_ctx.path.clone(),
             self.rng().map_err(|_| Error::EntropyMalfunction)?,
             full_store,
         );
@@ -110,7 +110,7 @@ impl<P: Platform> ServiceResources<P> {
 
         // prepare counterstore, bound to client_id, for counter calls
         let mut counterstore: ClientCounterstore<P::S> = ClientCounterstore::new(
-            client_id.path.clone(),
+            client_ctx.path.clone(),
             self.rng().map_err(|_| Error::EntropyMalfunction)?,
             full_store,
         );
@@ -118,7 +118,7 @@ impl<P: Platform> ServiceResources<P> {
 
         // prepare filestore, bound to client_id, for storage calls
         let mut filestore: ClientFilestore<P::S> =
-            ClientFilestore::new(client_id.path.clone(), full_store);
+            ClientFilestore::new(client_ctx.path.clone(), full_store);
         let filestore = &mut filestore;
 
         debug_now!("TRUSSED {:?}", request);
@@ -320,11 +320,11 @@ impl<P: Platform> ServiceResources<P> {
             Request::ReadDirFirst(request) => {
                 let maybe_entry = match filestore.read_dir_first(&request.dir, request.location, request.not_before_filename.as_ref())? {
                     Some((entry, read_dir_state)) => {
-                        client_id.read_dir_state = Some(read_dir_state);
+                        client_ctx.read_dir_state = Some(read_dir_state);
                         Some(entry)
                     }
                     None => {
-                        client_id.read_dir_state = None;
+                        client_ctx.read_dir_state = None;
                         None
 
                     }
@@ -334,18 +334,18 @@ impl<P: Platform> ServiceResources<P> {
 
             Request::ReadDirNext(_request) => {
                 // ensure next call has nothing to work with, unless we store state again
-                let read_dir_state = client_id.read_dir_state.take();
+                let read_dir_state = client_ctx.read_dir_state.take();
 
                 let maybe_entry = match read_dir_state {
                     None => None,
                     Some(state) => {
                         match filestore.read_dir_next(state)? {
                             Some((entry, read_dir_state)) => {
-                                client_id.read_dir_state = Some(read_dir_state);
+                                client_ctx.read_dir_state = Some(read_dir_state);
                                 Some(entry)
                             }
                             None => {
-                                client_id.read_dir_state = None;
+                                client_ctx.read_dir_state = None;
                                 None
                             }
                         }
@@ -358,11 +358,11 @@ impl<P: Platform> ServiceResources<P> {
             Request::ReadDirFilesFirst(request) => {
                 let maybe_data = match filestore.read_dir_files_first(&request.dir, request.location, request.user_attribute.clone())? {
                     Some((data, state)) => {
-                        client_id.read_dir_files_state = Some(state);
+                        client_ctx.read_dir_files_state = Some(state);
                         data
                     }
                     None => {
-                        client_id.read_dir_files_state = None;
+                        client_ctx.read_dir_files_state = None;
                         None
                     }
                 };
@@ -370,18 +370,18 @@ impl<P: Platform> ServiceResources<P> {
             }
 
             Request::ReadDirFilesNext(_request) => {
-                let read_dir_files_state = client_id.read_dir_files_state.take();
+                let read_dir_files_state = client_ctx.read_dir_files_state.take();
 
                 let maybe_data = match read_dir_files_state {
                     None => None,
                     Some(state) => {
                         match filestore.read_dir_files_next(state)? {
                             Some((data, state)) => {
-                                client_id.read_dir_files_state = Some(state);
+                                client_ctx.read_dir_files_state = Some(state);
                                 data
                             }
                             None => {
-                                client_id.read_dir_files_state = None;
+                                client_ctx.read_dir_files_state = None;
                                 None
                             }
                         }
@@ -720,8 +720,9 @@ impl<P: Platform> Service<P> {
     pub fn add_endpoint(
         &mut self,
         interchange: Responder<TrussedInterchange>,
-        client_ctx: ClientContext,
+        client_ctx: impl Into<ClientContext>,
     ) -> Result<(), ServiceEndpoint> {
+        let client_ctx = client_ctx.into();
         if client_ctx.path == PathBuf::from("trussed") {
             panic!("trussed is a reserved client ID");
         }

--- a/src/service.rs
+++ b/src/service.rs
@@ -58,7 +58,7 @@ where
 {
     pub(crate) platform: P,
     // // Option?
-    // currently_serving: ClientId,
+    // currently_serving: ClientContext,
     // TODO: how/when to clear
     read_dir_files_state: Option<ReadDirFilesState>,
     read_dir_state: Option<ReadDirState>,
@@ -90,7 +90,11 @@ unsafe impl<P: Platform> Send for Service<P> {}
 
 impl<P: Platform> ServiceResources<P> {
     #[inline(never)]
-    pub fn reply_to(&mut self, client_id: PathBuf, request: &Request) -> Result<Reply, Error> {
+    pub fn reply_to(
+        &mut self,
+        client_id: &mut ClientContext,
+        request: &Request,
+    ) -> Result<Reply, Error> {
         // TODO: what we want to do here is map an enum to a generic type
         // Is there a nicer way to do this?
 
@@ -98,7 +102,7 @@ impl<P: Platform> ServiceResources<P> {
 
         // prepare keystore, bound to client_id, for cryptographic calls
         let mut keystore: ClientKeystore<P::S> = ClientKeystore::new(
-            client_id.clone(),
+            client_id.path.clone(),
             self.rng().map_err(|_| Error::EntropyMalfunction)?,
             full_store,
         );
@@ -106,7 +110,7 @@ impl<P: Platform> ServiceResources<P> {
 
         // prepare certstore, bound to client_id, for cert calls
         let mut certstore: ClientCertstore<P::S> = ClientCertstore::new(
-            client_id.clone(),
+            client_id.path.clone(),
             self.rng().map_err(|_| Error::EntropyMalfunction)?,
             full_store,
         );
@@ -114,14 +118,15 @@ impl<P: Platform> ServiceResources<P> {
 
         // prepare counterstore, bound to client_id, for counter calls
         let mut counterstore: ClientCounterstore<P::S> = ClientCounterstore::new(
-            client_id.clone(),
+            client_id.path.clone(),
             self.rng().map_err(|_| Error::EntropyMalfunction)?,
             full_store,
         );
         let counterstore = &mut counterstore;
 
         // prepare filestore, bound to client_id, for storage calls
-        let mut filestore: ClientFilestore<P::S> = ClientFilestore::new(client_id, full_store);
+        let mut filestore: ClientFilestore<P::S> =
+            ClientFilestore::new(client_id.path.clone(), full_store);
         let filestore = &mut filestore;
 
         debug_now!("TRUSSED {:?}", request);
@@ -680,8 +685,8 @@ impl<P: Platform> Service<P> {
     ) -> Result<crate::client::ClientImplementation<S>, ()> {
         use interchange::Interchange;
         let (requester, responder) = TrussedInterchange::claim().ok_or(())?;
-        let client_id = ClientId::from(client_id.as_bytes());
-        self.add_endpoint(responder, client_id)
+        let client_ctx = ClientContext::from(client_id);
+        self.add_endpoint(responder, client_ctx)
             .map_err(|_service_endpoint| ())?;
 
         Ok(crate::client::ClientImplementation::new(requester, syscall))
@@ -697,8 +702,8 @@ impl<P: Platform> Service<P> {
     ) -> Result<crate::client::ClientImplementation<&mut Service<P>>, ()> {
         use interchange::Interchange;
         let (requester, responder) = TrussedInterchange::claim().ok_or(())?;
-        let client_id = ClientId::from(client_id.as_bytes());
-        self.add_endpoint(responder, client_id)
+        let client_ctx = ClientContext::from(client_id);
+        self.add_endpoint(responder, client_ctx)
             .map_err(|_service_endpoint| ())?;
 
         Ok(crate::client::ClientImplementation::new(requester, self))
@@ -713,8 +718,8 @@ impl<P: Platform> Service<P> {
     ) -> Result<crate::client::ClientImplementation<Service<P>>, ()> {
         use interchange::Interchange;
         let (requester, responder) = TrussedInterchange::claim().ok_or(())?;
-        let client_id = ClientId::from(client_id.as_bytes());
-        self.add_endpoint(responder, client_id)
+        let client_ctx = ClientContext::from(client_id);
+        self.add_endpoint(responder, client_ctx)
             .map_err(|_service_endpoint| ())?;
 
         Ok(crate::client::ClientImplementation::new(requester, self))
@@ -723,14 +728,14 @@ impl<P: Platform> Service<P> {
     pub fn add_endpoint(
         &mut self,
         interchange: Responder<TrussedInterchange>,
-        client_id: ClientId,
+        client_ctx: ClientContext,
     ) -> Result<(), ServiceEndpoint> {
-        if client_id == PathBuf::from("trussed") {
+        if client_ctx.path == PathBuf::from("trussed") {
             panic!("trussed is a reserved client ID");
         }
         self.eps.push(ServiceEndpoint {
             interchange,
-            client_id,
+            client_ctx,
         })
     }
 
@@ -773,7 +778,7 @@ impl<P: Platform> Service<P> {
                 // #[cfg(test)] println!("service got request: {:?}", &request);
 
                 // resources.currently_serving = ep.client_id.clone();
-                let reply_result = resources.reply_to(ep.client_id.clone(), &request);
+                let reply_result = resources.reply_to(&mut ep.client_ctx, &request);
 
                 resources
                     .platform

--- a/src/service.rs
+++ b/src/service.rs
@@ -72,7 +72,7 @@ pub struct Service<P>
 where
     P: Platform,
 {
-    eps: Vec<ServiceEndpoint<P::I>, { MAX_SERVICE_CLIENTS::USIZE }>,
+    eps: Vec<ServiceEndpoint<P::B, P::I>, { MAX_SERVICE_CLIENTS::USIZE }>,
     resources: ServiceResources<P>,
 }
 
@@ -83,8 +83,8 @@ impl<P: Platform> ServiceResources<P> {
     #[inline(never)]
     pub fn reply_to(
         &mut self,
-        client_ctx: &mut ClientContext,
-        request: &Request,
+        client_ctx: &mut ClientContext<P::B>,
+        request: &Request<P::B>,
     ) -> Result<Reply, Error> {
         // TODO: what we want to do here is map an enum to a generic type
         // Is there a nicer way to do this?
@@ -685,7 +685,7 @@ impl<P: Platform> Service<P> {
         &mut self,
         client_id: &str,
         syscall: S,
-    ) -> Result<crate::client::ClientImplementation<P::I, S>, ()> {
+    ) -> Result<crate::client::ClientImplementation<P::B, P::I, S>, ()> {
         use interchange::Interchange;
         let (requester, responder) = P::I::claim().ok_or(())?;
         let client_ctx = ClientContext::from(client_id);
@@ -702,7 +702,7 @@ impl<P: Platform> Service<P> {
     pub fn try_as_new_client(
         &mut self,
         client_id: &str,
-    ) -> Result<crate::client::ClientImplementation<P::I, &mut Service<P>>, ()> {
+    ) -> Result<crate::client::ClientImplementation<P::B, P::I, &mut Service<P>>, ()> {
         use interchange::Interchange;
         let (requester, responder) = P::I::claim().ok_or(())?;
         let client_ctx = ClientContext::from(client_id);
@@ -718,7 +718,7 @@ impl<P: Platform> Service<P> {
     pub fn try_into_new_client(
         mut self,
         client_id: &str,
-    ) -> Result<crate::client::ClientImplementation<P::I, Service<P>>, ()> {
+    ) -> Result<crate::client::ClientImplementation<P::B, P::I, Service<P>>, ()> {
         use interchange::Interchange;
         let (requester, responder) = P::I::claim().ok_or(())?;
         let client_ctx = ClientContext::from(client_id);
@@ -731,8 +731,8 @@ impl<P: Platform> Service<P> {
     pub fn add_endpoint(
         &mut self,
         interchange: Responder<P::I>,
-        client_ctx: impl Into<ClientContext>,
-    ) -> Result<(), ServiceEndpoint<P::I>> {
+        client_ctx: impl Into<ClientContext<P::B>>,
+    ) -> Result<(), ServiceEndpoint<P::B, P::I>> {
         let client_ctx = client_ctx.into();
         if client_ctx.path == PathBuf::from("trussed") {
             panic!("trussed is a reserved client ID");
@@ -786,10 +786,15 @@ impl<P: Platform> Service<P> {
 
                 let mut reply_result = Err(Error::RequestNotAvailable);
                 for backend in ep.client_ctx.backends.clone() {
-                    if backend == ServiceBackends::Software {
-                        reply_result = resources.reply_to(&mut ep.client_ctx, &request)
-                    } else if let Some(backend) = resources.platform.backend(backend) {
-                        reply_result = backend.reply_to(&mut ep.client_ctx, &request);
+                    match backend {
+                        ServiceBackends::Software => {
+                            reply_result = resources.reply_to(&mut ep.client_ctx, &request)
+                        }
+                        ServiceBackends::Custom(backend) => {
+                            if let Some(backend) = resources.platform.backend(backend) {
+                                reply_result = backend.reply_to(&mut ep.client_ctx, &request);
+                            }
+                        }
                     }
 
                     if reply_result != Err(Error::RequestNotAvailable) {

--- a/src/service.rs
+++ b/src/service.rs
@@ -66,12 +66,20 @@ impl<P: Platform> ServiceResources<P> {
             rng_state: None,
         }
     }
+
+    pub fn platform(&self) -> &P {
+        &self.platform
+    }
+
+    pub fn platform_mut(&mut self) -> &mut P {
+        &mut self.platform
+    }
 }
 
 pub struct Service<P, B>
 where
     P: Platform,
-    B: Backends<P::B>,
+    B: Backends<P>,
 {
     eps: Vec<ServiceEndpoint<P::B, P::I>, { MAX_SERVICE_CLIENTS::USIZE }>,
     resources: ServiceResources<P>,
@@ -79,7 +87,7 @@ where
 }
 
 // need to be able to send crypto service to an interrupt handler
-unsafe impl<P: Platform, B: Backends<P::B>> Send for Service<P, B> {}
+unsafe impl<P: Platform, B: Backends<P>> Send for Service<P, B> {}
 
 impl<P: Platform> ServiceResources<P> {
     #[inline(never)]
@@ -676,7 +684,7 @@ impl<P: Platform> Service<P, ()> {
     }
 }
 
-impl<P: Platform, B: Backends<P::B>> Service<P, B> {
+impl<P: Platform, B: Backends<P>> Service<P, B> {
     pub fn with_backends(platform: P, backends: B) -> Self {
         let resources = ServiceResources::new(platform);
         Self {
@@ -804,7 +812,8 @@ impl<P: Platform, B: Backends<P::B>> Service<P, B> {
                             }
                             ServiceBackends::Custom(backend) => {
                                 if let Some(backend) = self.backends.select(backend) {
-                                    reply_result = backend.reply_to(&mut ep.client_ctx, &request);
+                                    reply_result =
+                                        backend.reply_to(&mut ep.client_ctx, &request, resources);
                                 }
                             }
                         }
@@ -849,7 +858,7 @@ impl<P: Platform, B: Backends<P::B>> Service<P, B> {
 impl<P, B> crate::client::Syscall for &mut Service<P, B>
 where
     P: Platform,
-    B: Backends<P::B>,
+    B: Backends<P>,
 {
     fn syscall(&mut self) {
         self.process();
@@ -859,7 +868,7 @@ where
 impl<P, B> crate::client::Syscall for Service<P, B>
 where
     P: Platform,
-    B: Backends<P::B>,
+    B: Backends<P>,
 {
     fn syscall(&mut self) {
         self.process();

--- a/src/service.rs
+++ b/src/service.rs
@@ -57,11 +57,6 @@ where
     P: Platform,
 {
     pub(crate) platform: P,
-    // // Option?
-    // currently_serving: ClientContext,
-    // TODO: how/when to clear
-    read_dir_files_state: Option<ReadDirFilesState>,
-    read_dir_state: Option<ReadDirState>,
     rng_state: Option<ChaCha8Rng>,
 }
 
@@ -69,9 +64,6 @@ impl<P: Platform> ServiceResources<P> {
     pub fn new(platform: P) -> Self {
         Self {
             platform,
-            // currently_serving: PathBuf::new(),
-            read_dir_files_state: None,
-            read_dir_state: None,
             rng_state: None,
         }
     }
@@ -764,6 +756,7 @@ impl<P: Platform> Service<P> {
     }
 
     // process one request per client which has any
+    #[allow(unreachable_patterns)]
     pub fn process(&mut self) {
         // split self since we iter-mut over eps and need &mut of the other resources
         let eps = &mut self.eps;
@@ -784,6 +777,11 @@ impl<P: Platform> Service<P> {
                     reply_result = match backend {
                         ServiceBackends::Software => {
                             resources.reply_to(&mut ep.client_ctx, &request)
+                        }
+                        sb => {
+                            resources
+                                .platform
+                                .platform_reply_to(sb, &mut ep.client_ctx, &request)
                         }
                     };
                     if reply_result != Err(Error::RequestNotAvailable) {

--- a/src/service.rs
+++ b/src/service.rs
@@ -787,16 +787,12 @@ impl<P: Platform> Service<P> {
 
                 let mut reply_result = Err(Error::RequestNotAvailable);
                 for backend in ep.client_ctx.backends.clone() {
-                    reply_result = match backend {
-                        ServiceBackends::Software => {
-                            resources.reply_to(&mut ep.client_ctx, &request)
-                        }
-                        sb => {
-                            resources
-                                .platform
-                                .platform_reply_to(sb, &mut ep.client_ctx, &request)
-                        }
-                    };
+                    if backend == ServiceBackends::Software {
+                        reply_result = resources.reply_to(&mut ep.client_ctx, &request)
+                    } else if let Some(backend) = resources.platform.backend(backend) {
+                        reply_result = backend.reply_to(&mut ep.client_ctx, &request);
+                    }
+
                     if reply_result != Err(Error::RequestNotAvailable) {
                         break;
                     }

--- a/src/service.rs
+++ b/src/service.rs
@@ -575,11 +575,10 @@ impl<P: Platform> ServiceResources<P> {
                 /* as long as we don't do backend selection per syscall,
                    reject clients that want to drop the software backend;
 		   otherwise they will never be able to switch again! */
-                if !request.backends.contains(&ServiceBackends::Software) {
+                if !request.backends.is_empty() && !request.backends.contains(&ServiceBackends::Software) {
                     return Err(Error::InternalError);
                 }
-                client_ctx.backends.clear();
-                client_ctx.backends.extend_from_slice(&request.backends).unwrap();
+                client_ctx.backends = request.backends;
                 Ok(Reply::SetServiceBackends(reply::SetServiceBackends {}))
             }
 
@@ -785,20 +784,25 @@ impl<P: Platform> Service<P> {
                 // resources.currently_serving = ep.client_id.clone();
 
                 let mut reply_result = Err(Error::RequestNotAvailable);
-                for backend in ep.client_ctx.backends.clone() {
-                    match backend {
-                        ServiceBackends::Software => {
-                            reply_result = resources.reply_to(&mut ep.client_ctx, &request)
-                        }
-                        ServiceBackends::Custom(backend) => {
-                            if let Some(backend) = resources.platform.backend(backend) {
-                                reply_result = backend.reply_to(&mut ep.client_ctx, &request);
+                if ep.client_ctx.backends.is_empty() {
+                    // empty backend selection = software backend
+                    reply_result = resources.reply_to(&mut ep.client_ctx, &request);
+                } else {
+                    for backend in ep.client_ctx.backends {
+                        match backend {
+                            ServiceBackends::Software => {
+                                reply_result = resources.reply_to(&mut ep.client_ctx, &request)
+                            }
+                            ServiceBackends::Custom(backend) => {
+                                if let Some(backend) = resources.platform.backend(backend) {
+                                    reply_result = backend.reply_to(&mut ep.client_ctx, &request);
+                                }
                             }
                         }
-                    }
 
-                    if reply_result != Err(Error::RequestNotAvailable) {
-                        break;
+                        if reply_result != Err(Error::RequestNotAvailable) {
+                            break;
+                        }
                     }
                 }
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -778,7 +778,18 @@ impl<P: Platform> Service<P> {
                 // #[cfg(test)] println!("service got request: {:?}", &request);
 
                 // resources.currently_serving = ep.client_id.clone();
-                let reply_result = resources.reply_to(&mut ep.client_ctx, &request);
+
+                let mut reply_result = Err(Error::RequestNotAvailable);
+                for backend in ep.client_ctx.backends.clone() {
+                    reply_result = match backend {
+                        ServiceBackends::Software => {
+                            resources.reply_to(&mut ep.client_ctx, &request)
+                        }
+                    };
+                    if reply_result != Err(Error::RequestNotAvailable) {
+                        break;
+                    }
+                }
 
                 resources
                     .platform

--- a/src/store/certstore.rs
+++ b/src/store/certstore.rs
@@ -4,14 +4,14 @@ use littlefs2::path::PathBuf;
 use crate::{
     error::{Error, Result},
     store::{self, Store},
-    types::{CertId, ClientId, Location, Message},
+    types::{CertId, Location, Message},
 };
 
 pub struct ClientCertstore<S>
 where
     S: Store,
 {
-    client_id: ClientId,
+    client_id: PathBuf,
     rng: ChaCha8Rng,
     store: S,
 }
@@ -54,7 +54,7 @@ impl<S: Store> Certstore for ClientCertstore<S> {
 }
 
 impl<S: Store> ClientCertstore<S> {
-    pub fn new(client_id: ClientId, rng: ChaCha8Rng, store: S) -> Self {
+    pub fn new(client_id: PathBuf, rng: ChaCha8Rng, store: S) -> Self {
         Self {
             client_id,
             rng,

--- a/src/store/counterstore.rs
+++ b/src/store/counterstore.rs
@@ -4,14 +4,14 @@ use littlefs2::path::PathBuf;
 use crate::{
     error::{Error, Result},
     store::{self, Store},
-    types::{ClientId, CounterId, Location},
+    types::{CounterId, Location},
 };
 
 pub struct ClientCounterstore<S>
 where
     S: Store,
 {
-    client_id: ClientId,
+    client_id: PathBuf,
     rng: ChaCha8Rng,
     store: S,
 }
@@ -19,7 +19,7 @@ where
 pub type Counter = u128;
 
 impl<S: Store> ClientCounterstore<S> {
-    pub fn new(client_id: ClientId, rng: ChaCha8Rng, store: S) -> Self {
+    pub fn new(client_id: PathBuf, rng: ChaCha8Rng, store: S) -> Self {
         Self {
             client_id,
             rng,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -5,8 +5,8 @@ use crate::types::*;
 use crate::*;
 use entropy::shannon_entropy;
 use interchange::Interchange;
-use littlefs2::const_ram_storage;
 use littlefs2::fs::{Allocation, Filesystem};
+use littlefs2::{const_ram_storage, consts};
 
 use crate::client::{CryptoClient as _, FilesystemClient as _};
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -5,8 +5,8 @@ use crate::types::*;
 use crate::*;
 use entropy::shannon_entropy;
 use interchange::Interchange;
+use littlefs2::const_ram_storage;
 use littlefs2::fs::{Allocation, Filesystem};
-use littlefs2::{const_ram_storage, consts};
 
 use crate::client::{CryptoClient as _, FilesystemClient as _};
 
@@ -183,7 +183,7 @@ macro_rules! setup {
         let (test_trussed_requester, test_trussed_responder) =
             crate::pipe::TrussedInterchange::claim()
                 .expect("could not setup TEST TrussedInterchange");
-        let test_client_id = "TEST".into();
+        let test_client_id = "TEST";
 
         assert!(trussed
             .add_endpoint(test_trussed_responder, test_client_id)

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -187,7 +187,7 @@ macro_rules! setup {
         let pc_interface: UserInterface = Default::default();
 
         let platform = $platform::new(rng, store, pc_interface);
-        let mut trussed: crate::Service<$platform> = crate::service::Service::new(platform);
+        let mut trussed = crate::service::Service::new(platform);
 
         unsafe {
             TrussedInterchange::reset_claims();
@@ -205,7 +205,7 @@ macro_rules! setup {
             pub type TestClient<'a> = crate::ClientImplementation<
                 (),
                 TrussedInterchange,
-                &'a mut crate::Service<$platform>,
+                &'a mut crate::Service<$platform, ()>,
             >;
             TestClient::new(test_trussed_requester, &mut trussed)
         };

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -13,7 +13,7 @@ use littlefs2::fs::{Allocation, Filesystem};
 use crate::client::{CryptoClient as _, FilesystemClient as _};
 
 interchange::interchange! {
-    TrussedInterchange: (Request, Result<Reply, Error>, CLIENT_COUNT)
+    TrussedInterchange: (Request<()>, Result<Reply, Error>, CLIENT_COUNT)
 }
 
 pub struct MockRng(ChaCha20);
@@ -202,8 +202,11 @@ macro_rules! setup {
 
         trussed.set_seed_if_uninitialized(&$seed);
         let mut $client = {
-            pub type TestClient<'a> =
-                crate::ClientImplementation<TrussedInterchange, &'a mut crate::Service<$platform>>;
+            pub type TestClient<'a> = crate::ClientImplementation<
+                (),
+                TrussedInterchange,
+                &'a mut crate::Service<$platform>,
+            >;
             TestClient::new(test_trussed_requester, &mut trussed)
         };
     };

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,6 +1,7 @@
 #![cfg(test)]
 use chacha20::ChaCha20;
 
+use crate::pipe::TrussedInterchange;
 use crate::types::*;
 use crate::*;
 use entropy::shannon_entropy;
@@ -192,7 +193,7 @@ macro_rules! setup {
         trussed.set_seed_if_uninitialized(&$seed);
         let mut $client = {
             pub type TestClient<'a> =
-                crate::ClientImplementation<&'a mut crate::Service<$platform>>;
+                crate::ClientImplementation<TrussedInterchange, &'a mut crate::Service<$platform>>;
             TestClient::new(test_trussed_requester, &mut trussed)
         };
     };

--- a/src/types.rs
+++ b/src/types.rs
@@ -19,6 +19,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::config::*;
 use crate::key::Secrecy;
+use crate::store::filestore::{ReadDirFilesState, ReadDirState};
 
 pub use crate::client::FutureResult;
 pub use crate::platform::Platform;
@@ -235,10 +236,13 @@ pub mod consent {
 /**
 The "ClientId" struct is the closest equivalent to a PCB that Trussed
 currently has. Trussed currently uses it to choose the client-specific
-subtree in the filesystem (see docs in src/store.rs).
+subtree in the filesystem (see docs in src/store.rs) and to maintain
+the walker state of the directory traversal syscalls.
 */
 pub struct ClientContext {
     pub path: PathBuf,
+    pub(crate) read_dir_state: Option<ReadDirState>,
+    pub(crate) read_dir_files_state: Option<ReadDirFilesState>,
 }
 
 impl core::convert::From<PathBuf> for ClientContext {
@@ -255,7 +259,11 @@ impl core::convert::From<&str> for ClientContext {
 
 impl ClientContext {
     pub fn new(path: PathBuf) -> Self {
-        Self { path }
+        Self {
+            path,
+            read_dir_state: None,
+            read_dir_files_state: None,
+        }
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -17,7 +17,9 @@ pub use littlefs2::{
 use rand_core::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
 
+use crate::api::{Reply, Request};
 use crate::config::*;
+use crate::error::Error;
 use crate::key::Secrecy;
 use crate::store::filestore::{ReadDirFilesState, ReadDirState};
 
@@ -288,10 +290,21 @@ added as payload for that enum variant.
 Backends are called from Service::process() under consideration of the
 selection and ordering the calling client has specified in its ClientId.
 */
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone)]
 pub enum ServiceBackends {
     Software,
     // SE050(Se050Parameters),
+}
+
+/**
+Each service backend implements a subset of API calls through this trait.
+*/
+pub trait ServiceBackend {
+    fn reply_to(
+        &mut self,
+        client_id: &mut ClientContext,
+        request: &Request,
+    ) -> Result<Reply, Error>;
 }
 
 // Object Hierarchy according to Cryptoki

--- a/src/types.rs
+++ b/src/types.rs
@@ -230,12 +230,10 @@ pub mod consent {
 // pub type AeadNonce = [u8; 12];
 // pub type AeadTag = [u8; 16];
 
-/**
-The "ClientId" struct is the closest equivalent to a PCB that Trussed
-currently has. Trussed currently uses it to choose the client-specific
-subtree in the filesystem (see docs in src/store.rs) and to maintain
-the walker state of the directory traversal syscalls.
-*/
+// The "ClientContext" struct is the closest equivalent to a PCB that Trussed
+// currently has. Trussed currently uses it to choose the client-specific
+// subtree in the filesystem (see docs in src/store.rs) and to maintain
+// the walker state of the directory traversal syscalls.
 pub struct ClientContext<B> {
     pub path: PathBuf,
     pub backends: Vec<ServiceBackends<B>, 2>,
@@ -268,30 +266,26 @@ impl<B> ClientContext<B> {
     }
 }
 
-/**
-This enum collects the available "system call" service backends.
-Each of these backends is supposed to be self-sufficient (i.e. not reliant
-on another one or on ServiceResources itself) and to implement a subset
-of the API calls.
-
-If a backend requires ownership of a device, that device will be part of
-the customizable part of the macro-constructed Platform struct. If a
-backend further requires parametrization from the client to operate (such as
-a PIN being passed down from an app), this parameter struct should be
-added as payload for that enum variant.
-
-Backends are called from Service::process() under consideration of the
-selection and ordering the calling client has specified in its ClientId.
-*/
+/// This enum collects the available "system call" service backends.
+/// Each of these backends is supposed to be self-sufficient (i.e. not reliant
+/// on another one or on ServiceResources itself) and to implement a subset
+/// of the API calls.
+///
+/// If a backend requires ownership of a device, that device will be part of
+/// the customizable part of the macro-constructed Platform struct. If a
+/// backend further requires parametrization from the client to operate (such as
+/// a PIN being passed down from an app), this parameter struct should be
+/// added as payload for that enum variant.
+///
+/// Backends are called from Service::process() under consideration of the
+/// selection and ordering the calling client has specified in its ClientContext.
 #[derive(Copy, Clone, PartialEq, Eq, Debug, serde::Serialize, serde::Deserialize)]
 pub enum ServiceBackends<B> {
     Software,
     Custom(B),
 }
 
-/**
-Each service backend implements a subset of API calls through this trait.
-*/
+/// Each service backend implements a subset of API calls through this trait.
 pub trait ServiceBackend<B> {
     fn reply_to(
         &mut self,

--- a/src/types.rs
+++ b/src/types.rs
@@ -243,25 +243,21 @@ pub struct ClientContext<B> {
     pub(crate) read_dir_files_state: Option<ReadDirFilesState>,
 }
 
-impl<B> core::convert::From<PathBuf> for ClientContext<B> {
+impl<B> From<PathBuf> for ClientContext<B> {
     fn from(path: PathBuf) -> Self {
-        Self::from_pathbuf(path)
-    }
-}
-
-impl<B> core::convert::From<&str> for ClientContext<B> {
-    fn from(path_str: &str) -> Self {
-        Self::from_pathbuf(PathBuf::from(path_str))
-    }
-}
-
-impl<B> ClientContext<B> {
-    pub fn from_pathbuf(path: PathBuf) -> Self {
         let mut backends = Vec::new();
         backends.push(ServiceBackends::Software).ok().unwrap();
         Self::new(path, backends)
     }
+}
 
+impl<B> From<&str> for ClientContext<B> {
+    fn from(path_str: &str) -> Self {
+        PathBuf::from(path_str).into()
+    }
+}
+
+impl<B> ClientContext<B> {
     pub fn new(path: PathBuf, backends: Vec<ServiceBackends<B>, 2>) -> Self {
         Self {
             path,

--- a/src/types.rs
+++ b/src/types.rs
@@ -292,6 +292,16 @@ pub trait ServiceBackend<B> {
     ) -> Result<Reply, Error>;
 }
 
+pub trait Backends<B> {
+    fn select(&mut self, backend: &B) -> Option<&mut dyn ServiceBackend<B>>;
+}
+
+impl<B> Backends<B> for () {
+    fn select(&mut self, _backend: &B) -> Option<&mut dyn ServiceBackend<B>> {
+        None
+    }
+}
+
 // Object Hierarchy according to Cryptoki
 // - Storage
 //   - Domain parameters

--- a/src/types.rs
+++ b/src/types.rs
@@ -22,6 +22,7 @@ use crate::api::{Reply, Request};
 use crate::config::*;
 use crate::error::Error;
 use crate::key::Secrecy;
+use crate::service::ServiceResources;
 use crate::store::filestore::{ReadDirFilesState, ReadDirState};
 
 pub use crate::client::FutureResult;
@@ -284,20 +285,21 @@ pub enum ServiceBackends<B> {
 }
 
 /// Each service backend implements a subset of API calls through this trait.
-pub trait ServiceBackend<B> {
+pub trait ServiceBackend<P: Platform> {
     fn reply_to(
         &mut self,
-        client_id: &mut ClientContext<B>,
-        request: &Request<B>,
+        client_id: &mut ClientContext<P::B>,
+        request: &Request<P::B>,
+        resources: &mut ServiceResources<P>,
     ) -> Result<Reply, Error>;
 }
 
-pub trait Backends<B> {
-    fn select(&mut self, backend: &B) -> Option<&mut dyn ServiceBackend<B>>;
+pub trait Backends<P: Platform> {
+    fn select(&mut self, backend: &P::B) -> Option<&mut dyn ServiceBackend<P>>;
 }
 
-impl<B> Backends<B> for () {
-    fn select(&mut self, _backend: &B) -> Option<&mut dyn ServiceBackend<B>> {
+impl<P: Platform> Backends<P> for () {
+    fn select(&mut self, _backend: &P::B) -> Option<&mut dyn ServiceBackend<P>> {
         None
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -273,6 +273,33 @@ impl ClientContext {
             read_dir_files_state: None,
         }
     }
+
+    pub fn builder(path: PathBuf) -> ClientContextBuilder {
+        ClientContextBuilder::new(path)
+    }
+}
+
+pub struct ClientContextBuilder {
+    pub path: PathBuf,
+    pub backends: Vec<ServiceBackends, 2>,
+}
+
+impl ClientContextBuilder {
+    pub fn new(path: PathBuf) -> Self {
+        Self {
+            path,
+            backends: Vec::from_slice(&[ServiceBackends::Software]).unwrap(),
+        }
+    }
+
+    pub fn add_backend(&mut self, backend: ServiceBackends) -> &ClientContextBuilder {
+        self.backends.insert(0, backend).unwrap();
+        self
+    }
+
+    pub fn build(&self) -> ClientContext {
+        ClientContext::new(self.path.clone(), self.backends.clone())
+    }
 }
 
 /**
@@ -290,9 +317,10 @@ added as payload for that enum variant.
 Backends are called from Service::process() under consideration of the
 selection and ordering the calling client has specified in its ClientId.
 */
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub enum ServiceBackends {
     Software,
+    SoftwareAuth,
     // SE050(Se050Parameters),
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -232,8 +232,32 @@ pub mod consent {
 // pub type AeadNonce = [u8; 12];
 // pub type AeadTag = [u8; 16];
 
-// pub type ClientId = heapless::Vec<u8, heapless::consts::U32>;
-pub type ClientId = PathBuf;
+/**
+The "ClientId" struct is the closest equivalent to a PCB that Trussed
+currently has. Trussed currently uses it to choose the client-specific
+subtree in the filesystem (see docs in src/store.rs).
+*/
+pub struct ClientContext {
+    pub path: PathBuf,
+}
+
+impl core::convert::From<PathBuf> for ClientContext {
+    fn from(path: PathBuf) -> Self {
+        Self::new(path)
+    }
+}
+
+impl core::convert::From<&str> for ClientContext {
+    fn from(path_str: &str) -> Self {
+        Self::new(PathBuf::from(path_str))
+    }
+}
+
+impl ClientContext {
+    pub fn new(path: PathBuf) -> Self {
+        Self { path }
+    }
+}
 
 // Object Hierarchy according to Cryptoki
 // - Storage

--- a/src/types.rs
+++ b/src/types.rs
@@ -68,13 +68,12 @@ impl Id {
         self.0 < 256
     }
 
-    /// skips leading zeros
     pub fn hex(&self) -> Bytes<32> {
         const HEX_CHARS: &[u8] = b"0123456789abcdef";
         let mut buffer = Bytes::new();
         let array = self.0.to_be_bytes();
 
-        for i in 0 .. array.len() {
+        for i in 0..array.len() {
             buffer.push(HEX_CHARS[(array[i] >> 4) as usize]).unwrap();
             buffer.push(HEX_CHARS[(array[i] & 0xf) as usize]).unwrap();
         }

--- a/src/types.rs
+++ b/src/types.rs
@@ -234,29 +234,27 @@ pub mod consent {
 // currently has. Trussed currently uses it to choose the client-specific
 // subtree in the filesystem (see docs in src/store.rs) and to maintain
 // the walker state of the directory traversal syscalls.
-pub struct ClientContext<B> {
+pub struct ClientContext<B: 'static> {
     pub path: PathBuf,
-    pub backends: Vec<ServiceBackends<B>, 2>,
+    pub backends: &'static [ServiceBackends<B>],
     pub(crate) read_dir_state: Option<ReadDirState>,
     pub(crate) read_dir_files_state: Option<ReadDirFilesState>,
 }
 
-impl<B> From<PathBuf> for ClientContext<B> {
+impl<B: 'static> From<PathBuf> for ClientContext<B> {
     fn from(path: PathBuf) -> Self {
-        let mut backends = Vec::new();
-        backends.push(ServiceBackends::Software).ok().unwrap();
-        Self::new(path, backends)
+        Self::new(path, &[])
     }
 }
 
-impl<B> From<&str> for ClientContext<B> {
+impl<B: 'static> From<&str> for ClientContext<B> {
     fn from(path_str: &str) -> Self {
         PathBuf::from(path_str).into()
     }
 }
 
-impl<B> ClientContext<B> {
-    pub fn new(path: PathBuf, backends: Vec<ServiceBackends<B>, 2>) -> Self {
+impl<B: 'static> ClientContext<B> {
+    pub fn new(path: PathBuf, backends: &'static [ServiceBackends<B>]) -> Self {
         Self {
             path,
             backends,

--- a/src/types.rs
+++ b/src/types.rs
@@ -272,35 +272,6 @@ impl<B> ClientContext<B> {
     }
 }
 
-impl<B: Clone + Debug> ClientContext<B> {
-    pub fn builder(path: PathBuf) -> ClientContextBuilder<B> {
-        ClientContextBuilder::new(path)
-    }
-}
-
-pub struct ClientContextBuilder<B> {
-    pub path: PathBuf,
-    pub backends: Vec<ServiceBackends<B>, 2>,
-}
-
-impl<B: Clone + Debug> ClientContextBuilder<B> {
-    pub fn new(path: PathBuf) -> Self {
-        Self {
-            path,
-            backends: Vec::from_slice(&[ServiceBackends::Software]).unwrap(),
-        }
-    }
-
-    pub fn add_backend(&mut self, backend: ServiceBackends<B>) -> &ClientContextBuilder<B> {
-        self.backends.insert(0, backend).unwrap();
-        self
-    }
-
-    pub fn build(&self) -> ClientContext<B> {
-        ClientContext::new(self.path.clone(), self.backends.clone())
-    }
-}
-
 /**
 This enum collects the available "system call" service backends.
 Each of these backends is supposed to be self-sufficient (i.e. not reliant

--- a/src/types.rs
+++ b/src/types.rs
@@ -74,12 +74,7 @@ impl Id {
         let mut buffer = Bytes::new();
         let array = self.0.to_be_bytes();
 
-        for i in 0..array.len() {
-            if array[i] == 0 && i != (array.len() - 1) {
-                // Skip leading zeros.
-                continue;
-            }
-
+        for i in 0 .. array.len() {
             buffer.push(HEX_CHARS[(array[i] >> 4) as usize]).unwrap();
             buffer.push(HEX_CHARS[(array[i] & 0xf) as usize]).unwrap();
         }
@@ -317,7 +312,7 @@ added as payload for that enum variant.
 Backends are called from Service::process() under consideration of the
 selection and ordering the calling client has specified in its ClientId.
 */
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, serde::Serialize, serde::Deserialize)]
 pub enum ServiceBackends {
     Software,
     SoftwareAuth,

--- a/src/virt.rs
+++ b/src/virt.rs
@@ -18,7 +18,7 @@ use crate::{
 pub use store::{Filesystem, Ram, StoreProvider};
 pub use ui::UserInterface;
 
-pub type Client<S> = ClientImplementation<Service<Platform<S>>>;
+pub type Client<S> = ClientImplementation<TrussedInterchange, Service<Platform<S>>>;
 
 // We need this mutex to make sure that:
 // - TrussedInterchange is not used concurrently
@@ -78,7 +78,7 @@ impl<S: StoreProvider> Platform<S> {
     pub fn run_client<R>(
         self,
         client_id: &str,
-        test: impl FnOnce(ClientImplementation<Service<Self>>) -> R,
+        test: impl FnOnce(ClientImplementation<TrussedInterchange, Service<Self>>) -> R,
     ) -> R {
         let service = Service::new(self);
         let client = service.try_into_new_client(client_id).unwrap();
@@ -87,6 +87,7 @@ impl<S: StoreProvider> Platform<S> {
 }
 
 unsafe impl<S: StoreProvider> platform::Platform for Platform<S> {
+    type I = TrussedInterchange;
     type R = ChaCha8Rng;
     type S = S::Store;
     type UI = UserInterface;

--- a/src/virt.rs
+++ b/src/virt.rs
@@ -24,10 +24,10 @@ pub use store::{Filesystem, Ram, StoreProvider};
 pub use ui::UserInterface;
 
 interchange::interchange! {
-    TrussedInterchange: (Request, Result<Reply, Error>, CLIENT_COUNT)
+    TrussedInterchange: (Request<()>, Result<Reply, Error>, CLIENT_COUNT)
 }
 
-pub type Client<S> = ClientImplementation<TrussedInterchange, Service<Platform<S>>>;
+pub type Client<S> = ClientImplementation<(), TrussedInterchange, Service<Platform<S>>>;
 
 // We need this mutex to make sure that:
 // - TrussedInterchange is not used concurrently
@@ -87,7 +87,7 @@ impl<S: StoreProvider> Platform<S> {
     pub fn run_client<R>(
         self,
         client_id: &str,
-        test: impl FnOnce(ClientImplementation<TrussedInterchange, Service<Self>>) -> R,
+        test: impl FnOnce(ClientImplementation<(), TrussedInterchange, Service<Self>>) -> R,
     ) -> R {
         let service = Service::new(self);
         let client = service.try_into_new_client(client_id).unwrap();
@@ -96,6 +96,7 @@ impl<S: StoreProvider> Platform<S> {
 }
 
 unsafe impl<S: StoreProvider> platform::Platform for Platform<S> {
+    type B = ();
     type I = TrussedInterchange;
     type R = ChaCha8Rng;
     type S = S::Store;

--- a/src/virt.rs
+++ b/src/virt.rs
@@ -97,7 +97,7 @@ impl<S: StoreProvider, I: TrussedInterchange<B>, B: 'static + Debug + PartialEq>
         }
     }
 
-    pub fn run_client<R, Bs: Backends<B>>(
+    pub fn run_client<R, Bs: Backends<Self>>(
         self,
         client_id: &str,
         backends: Bs,

--- a/src/virt.rs
+++ b/src/virt.rs
@@ -12,7 +12,13 @@ use chacha20::ChaCha8Rng;
 use rand_core::SeedableRng as _;
 
 use crate::{
-    pipe::TrussedInterchange, platform, service::Service, ClientImplementation, Interchange as _,
+    api::{Reply, Request},
+    error::Error,
+    pipe::TrussedInterchange,
+    platform,
+    service::Service,
+    types::{ClientContext, ServiceBackends},
+    ClientImplementation, Interchange as _,
 };
 
 pub use store::{Filesystem, Ram, StoreProvider};
@@ -101,5 +107,14 @@ unsafe impl<S: StoreProvider> platform::Platform for Platform<S> {
 
     fn store(&self) -> Self::S {
         unsafe { S::store() }
+    }
+
+    fn platform_reply_to(
+        &mut self,
+        _backend_id: ServiceBackends,
+        _client_id: &mut ClientContext,
+        _request: &Request,
+    ) -> Result<Reply, Error> {
+        Err(Error::RequestNotAvailable)
     }
 }

--- a/src/virt.rs
+++ b/src/virt.rs
@@ -12,13 +12,7 @@ use chacha20::ChaCha8Rng;
 use rand_core::SeedableRng as _;
 
 use crate::{
-    api::{Reply, Request},
-    error::Error,
-    pipe::TrussedInterchange,
-    platform,
-    service::Service,
-    types::{ClientContext, ServiceBackends},
-    ClientImplementation, Interchange as _,
+    pipe::TrussedInterchange, platform, service::Service, ClientImplementation, Interchange as _,
 };
 
 pub use store::{Filesystem, Ram, StoreProvider};
@@ -107,14 +101,5 @@ unsafe impl<S: StoreProvider> platform::Platform for Platform<S> {
 
     fn store(&self) -> Self::S {
         unsafe { S::store() }
-    }
-
-    fn platform_reply_to(
-        &mut self,
-        _backend_id: ServiceBackends,
-        _client_id: &mut ClientContext,
-        _request: &Request,
-    ) -> Result<Reply, Error> {
-        Err(Error::RequestNotAvailable)
     }
 }

--- a/src/virt.rs
+++ b/src/virt.rs
@@ -7,6 +7,7 @@ mod store;
 mod ui;
 
 use std::{
+    fmt::Debug,
     path::PathBuf,
     sync::{Mutex, MutexGuard},
 };
@@ -125,16 +126,17 @@ unsafe impl<S: StoreProvider, B: Backends> platform::Platform for Platform<S, B>
         unsafe { S::store() }
     }
 
-    fn backend(&mut self, backend: Self::B) -> Option<&mut dyn ServiceBackend<Self::B>> {
+    fn backend(&mut self, backend: &Self::B) -> Option<&mut dyn ServiceBackend<Self::B>> {
         self.backends.select(backend)
     }
 }
 
 pub trait Backends {
-    type Backend: Clone + PartialEq;
+    type Backend: 'static + Debug + PartialEq;
     type Interchange: TrussedInterchange<Self::Backend>;
 
-    fn select(&mut self, backend: Self::Backend) -> Option<&mut dyn ServiceBackend<Self::Backend>>;
+    fn select(&mut self, backend: &Self::Backend)
+        -> Option<&mut dyn ServiceBackend<Self::Backend>>;
 }
 
 impl Backends for () {
@@ -143,7 +145,7 @@ impl Backends for () {
 
     fn select(
         &mut self,
-        _backend: Self::Backend,
+        _backend: &Self::Backend,
     ) -> Option<&mut dyn ServiceBackend<Self::Backend>> {
         None
     }

--- a/src/virt.rs
+++ b/src/virt.rs
@@ -6,7 +6,10 @@
 mod store;
 mod ui;
 
-use std::{path::PathBuf, sync::Mutex};
+use std::{
+    path::PathBuf,
+    sync::{Mutex, MutexGuard},
+};
 
 use chacha20::ChaCha8Rng;
 use rand_core::SeedableRng as _;
@@ -14,9 +17,10 @@ use rand_core::SeedableRng as _;
 use crate::{
     api::{Reply, Request},
     error::Error,
-    pipe::CLIENT_COUNT,
+    pipe::{TrussedInterchange, CLIENT_COUNT},
     platform,
     service::Service,
+    types::ServiceBackend,
     ClientImplementation, Interchange as _,
 };
 
@@ -24,13 +28,13 @@ pub use store::{Filesystem, Ram, StoreProvider};
 pub use ui::UserInterface;
 
 interchange::interchange! {
-    TrussedInterchange: (Request<()>, Result<Reply, Error>, CLIENT_COUNT)
+    SimpleInterchange: (Request<()>, Result<Reply, Error>, CLIENT_COUNT)
 }
 
-pub type Client<S> = ClientImplementation<(), TrussedInterchange, Service<Platform<S>>>;
+pub type Client<S> = ClientImplementation<(), SimpleInterchange, Service<Platform<S>>>;
 
 // We need this mutex to make sure that:
-// - TrussedInterchange is not used concurrently
+// - the interchange is not used concurrently
 // - the Store is not used concurrently
 static MUTEX: Mutex<()> = Mutex::new(());
 
@@ -39,19 +43,7 @@ where
     S: StoreProvider,
     F: FnOnce(Platform<S>) -> R,
 {
-    let _guard = MUTEX.lock().unwrap_or_else(|err| err.into_inner());
-    unsafe {
-        TrussedInterchange::reset_claims();
-        store.reset();
-    }
-    // causing a regression again
-    // let rng = chacha20::ChaCha8Rng::from_rng(rand_core::OsRng).unwrap();
-    let platform = Platform {
-        rng: ChaCha8Rng::from_seed([42u8; 32]),
-        _store: store,
-        ui: UserInterface::new(),
-    };
-    f(platform)
+    f(Platform::new(store, ()))
 }
 
 pub fn with_client<S, R, F>(store: S, client_id: &str, f: F) -> R
@@ -59,7 +51,7 @@ where
     S: StoreProvider,
     F: FnOnce(Client<S>) -> R,
 {
-    with_platform(store, |platform| platform.run_client(client_id, f))
+    Platform::new(store, ()).run_client(client_id, f)
 }
 
 pub fn with_fs_client<P, R, F>(internal: P, client_id: &str, f: F) -> R
@@ -67,27 +59,46 @@ where
     P: Into<PathBuf>,
     F: FnOnce(Client<Filesystem>) -> R,
 {
-    with_client(Filesystem::new(internal), client_id, f)
+    Platform::new(Filesystem::new(internal), ()).run_client(client_id, f)
 }
 
 pub fn with_ram_client<R, F>(client_id: &str, f: F) -> R
 where
     F: FnOnce(Client<Ram>) -> R,
 {
-    with_client(Ram::default(), client_id, f)
+    Platform::new(Ram::default(), ()).run_client(client_id, f)
 }
 
-pub struct Platform<S: StoreProvider> {
+pub struct Platform<S: StoreProvider, B = ()> {
     rng: ChaCha8Rng,
     _store: S,
     ui: UserInterface,
+    backends: B,
+    _guard: MutexGuard<'static, ()>,
 }
 
-impl<S: StoreProvider> Platform<S> {
+impl<S: StoreProvider, B: Backends> Platform<S, B> {
+    pub fn new(store: S, backends: B) -> Self {
+        let _guard = MUTEX.lock().unwrap_or_else(|err| err.into_inner());
+        unsafe {
+            B::Interchange::reset_claims();
+            store.reset();
+        }
+        // causing a regression again
+        // let rng = chacha20::ChaCha8Rng::from_rng(rand_core::OsRng).unwrap();
+        Self {
+            rng: ChaCha8Rng::from_seed([42u8; 32]),
+            _store: store,
+            ui: UserInterface::new(),
+            backends,
+            _guard,
+        }
+    }
+
     pub fn run_client<R>(
         self,
         client_id: &str,
-        test: impl FnOnce(ClientImplementation<(), TrussedInterchange, Service<Self>>) -> R,
+        test: impl FnOnce(ClientImplementation<B::Backend, B::Interchange, Service<Self>>) -> R,
     ) -> R {
         let service = Service::new(self);
         let client = service.try_into_new_client(client_id).unwrap();
@@ -95,9 +106,9 @@ impl<S: StoreProvider> Platform<S> {
     }
 }
 
-unsafe impl<S: StoreProvider> platform::Platform for Platform<S> {
-    type B = ();
-    type I = TrussedInterchange;
+unsafe impl<S: StoreProvider, B: Backends> platform::Platform for Platform<S, B> {
+    type B = B::Backend;
+    type I = B::Interchange;
     type R = ChaCha8Rng;
     type S = S::Store;
     type UI = UserInterface;
@@ -112,5 +123,28 @@ unsafe impl<S: StoreProvider> platform::Platform for Platform<S> {
 
     fn store(&self) -> Self::S {
         unsafe { S::store() }
+    }
+
+    fn backend(&mut self, backend: Self::B) -> Option<&mut dyn ServiceBackend<Self::B>> {
+        self.backends.select(backend)
+    }
+}
+
+pub trait Backends {
+    type Backend: Clone + PartialEq;
+    type Interchange: TrussedInterchange<Self::Backend>;
+
+    fn select(&mut self, backend: Self::Backend) -> Option<&mut dyn ServiceBackend<Self::Backend>>;
+}
+
+impl Backends for () {
+    type Backend = ();
+    type Interchange = SimpleInterchange;
+
+    fn select(
+        &mut self,
+        _backend: Self::Backend,
+    ) -> Option<&mut dyn ServiceBackend<Self::Backend>> {
+        None
     }
 }

--- a/src/virt.rs
+++ b/src/virt.rs
@@ -12,11 +12,20 @@ use chacha20::ChaCha8Rng;
 use rand_core::SeedableRng as _;
 
 use crate::{
-    pipe::TrussedInterchange, platform, service::Service, ClientImplementation, Interchange as _,
+    api::{Reply, Request},
+    error::Error,
+    pipe::CLIENT_COUNT,
+    platform,
+    service::Service,
+    ClientImplementation, Interchange as _,
 };
 
 pub use store::{Filesystem, Ram, StoreProvider};
 pub use ui::UserInterface;
+
+interchange::interchange! {
+    TrussedInterchange: (Request, Result<Reply, Error>, CLIENT_COUNT)
+}
 
 pub type Client<S> = ClientImplementation<TrussedInterchange, Service<Platform<S>>>;
 

--- a/tests/backends.rs
+++ b/tests/backends.rs
@@ -6,10 +6,16 @@ use trussed::{
     error::Error,
     pipe::CLIENT_COUNT,
     service::Service,
-    types::{ClientContext, Location, Message, PathBuf, ServiceBackend, ServiceBackends},
-    virt::{self, Platform, Ram},
+    types::{self, ClientContext, Location, Message, PathBuf, ServiceBackend, ServiceBackends},
+    virt::{Platform, Ram},
     ClientImplementation,
 };
+
+type Client = ClientImplementation<
+    Backend,
+    Interchange,
+    Service<Platform<Ram, Interchange, Backend>, Backends>,
+>;
 
 const BACKENDS_TEST: &[ServiceBackends<Backend>] = &[
     ServiceBackends::Custom(Backend::Test),
@@ -26,14 +32,8 @@ struct Backends {
     test: TestBackend,
 }
 
-impl virt::Backends for Backends {
-    type Backend = Backend;
-    type Interchange = Interchange;
-
-    fn select(
-        &mut self,
-        backend: &Self::Backend,
-    ) -> Option<&mut dyn ServiceBackend<Self::Backend>> {
+impl types::Backends<Backend> for Backends {
+    fn select(&mut self, backend: &Backend) -> Option<&mut dyn ServiceBackend<Backend>> {
         match backend {
             Backend::Test => Some(&mut self.test),
         }
@@ -64,12 +64,9 @@ interchange::interchange! {
     Interchange: (Request<Backend>, Result<Reply, Error>, CLIENT_COUNT)
 }
 
-fn run<F>(f: F)
-where
-    F: FnOnce(&mut ClientImplementation<Backend, Interchange, Service<Platform<Ram, Backends>>>),
-{
-    Platform::new(Ram::default(), Backends::default())
-        .run_client("test", |mut client| f(&mut client))
+fn run<F: FnOnce(&mut Client)>(f: F) {
+    Platform::new(Ram::default())
+        .run_client("test", Backends::default(), |mut client| f(&mut client))
 }
 
 #[test]

--- a/tests/backends.rs
+++ b/tests/backends.rs
@@ -1,0 +1,86 @@
+#![cfg(feature = "virt")]
+
+use heapless::Vec;
+use trussed::{
+    api::{reply::ReadFile, Reply, Request},
+    client::{FilesystemClient as _, PollClient as _},
+    error::Error,
+    pipe::CLIENT_COUNT,
+    service::Service,
+    types::{ClientContext, Location, Message, PathBuf, ServiceBackend, ServiceBackends},
+    virt::{self, Platform, Ram},
+    ClientImplementation,
+};
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum Backend {
+    Test,
+}
+
+#[derive(Default)]
+struct Backends {
+    test: TestBackend,
+}
+
+impl virt::Backends for Backends {
+    type Backend = Backend;
+    type Interchange = Interchange;
+
+    fn select(&mut self, backend: Self::Backend) -> Option<&mut dyn ServiceBackend<Self::Backend>> {
+        match backend {
+            Backend::Test => Some(&mut self.test),
+        }
+    }
+}
+
+#[derive(Default)]
+struct TestBackend;
+
+impl<B> ServiceBackend<B> for TestBackend {
+    fn reply_to(
+        &mut self,
+        _client_id: &mut ClientContext<B>,
+        request: &Request<B>,
+    ) -> Result<Reply, Error> {
+        match request {
+            Request::ReadFile(_) => {
+                let mut data = Message::new();
+                data.push(0xff).unwrap();
+                Ok(Reply::ReadFile(ReadFile { data }))
+            }
+            _ => Err(Error::RequestNotAvailable),
+        }
+    }
+}
+
+interchange::interchange! {
+    Interchange: (Request<Backend>, Result<Reply, Error>, CLIENT_COUNT)
+}
+
+fn run<F>(f: F)
+where
+    F: FnOnce(&mut ClientImplementation<Backend, Interchange, Service<Platform<Ram, Backends>>>),
+{
+    Platform::new(Ram::default(), Backends::default())
+        .run_client("test", |mut client| f(&mut client))
+}
+
+#[test]
+fn override_syscall() {
+    run(|client| {
+        let path = PathBuf::from("test");
+        assert!(trussed::try_syscall!(client.read_file(Location::Internal, path.clone())).is_err());
+
+        let mut backends = Vec::new();
+        backends
+            .push(ServiceBackends::Custom(Backend::Test))
+            .unwrap();
+        backends.push(ServiceBackends::Software).unwrap();
+        trussed::syscall!(client.set_service_backends(backends));
+
+        assert_eq!(
+            trussed::syscall!(client.read_file(Location::Internal, path)).data,
+            &[0xff]
+        );
+    })
+}

--- a/tests/backends.rs
+++ b/tests/backends.rs
@@ -1,6 +1,5 @@
 #![cfg(feature = "virt")]
 
-use heapless::Vec;
 use trussed::{
     api::{reply::ReadFile, Reply, Request},
     client::{FilesystemClient as _, PollClient as _},
@@ -11,6 +10,11 @@ use trussed::{
     virt::{self, Platform, Ram},
     ClientImplementation,
 };
+
+const BACKENDS_TEST: &[ServiceBackends<Backend>] = &[
+    ServiceBackends::Custom(Backend::Test),
+    ServiceBackends::Software,
+];
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum Backend {
@@ -26,7 +30,10 @@ impl virt::Backends for Backends {
     type Backend = Backend;
     type Interchange = Interchange;
 
-    fn select(&mut self, backend: Self::Backend) -> Option<&mut dyn ServiceBackend<Self::Backend>> {
+    fn select(
+        &mut self,
+        backend: &Self::Backend,
+    ) -> Option<&mut dyn ServiceBackend<Self::Backend>> {
         match backend {
             Backend::Test => Some(&mut self.test),
         }
@@ -71,12 +78,7 @@ fn override_syscall() {
         let path = PathBuf::from("test");
         assert!(trussed::try_syscall!(client.read_file(Location::Internal, path.clone())).is_err());
 
-        let mut backends = Vec::new();
-        backends
-            .push(ServiceBackends::Custom(Backend::Test))
-            .unwrap();
-        backends.push(ServiceBackends::Software).unwrap();
-        trussed::syscall!(client.set_service_backends(backends));
+        trussed::syscall!(client.set_service_backends(BACKENDS_TEST));
 
         assert_eq!(
             trussed::syscall!(client.read_file(Location::Internal, path)).data,


### PR DESCRIPTION
Open questions:

* we still use a `Vec<_, 2>` for backend selection – that is not flexible enough for the generic implementation
* naming: do we need the `Service` prefix? and the `ServiceBackends` enum should be singular, but that clashes with the `ServiceBackend` trait
* move the backend stuff into a `backend` module?