### PR TITLE
Add custom UI status

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -82,6 +82,7 @@ generate_enums! {
     Reboot: 42
     Uptime: 43
     Wink: 44
+    SetCustomStatus: 45
 
     //////////////
     // Counters //
@@ -325,6 +326,9 @@ pub mod request {
         Wink:
           - duration: core::time::Duration
 
+        SetCustomStatus:
+          - status: u8
+
         CreateCounter:
           - location: Location
 
@@ -480,6 +484,8 @@ pub mod reply {
           - uptime: Duration
 
         Wink:
+
+        SetCustomStatus:
 
         CreateCounter:
           - id: CounterId

--- a/src/client.rs
+++ b/src/client.rs
@@ -688,6 +688,10 @@ pub trait UiClient: PollClient {
     fn wink(&mut self, duration: core::time::Duration) -> ClientResult<'_, reply::Wink, Self> {
         self.request(request::Wink { duration })
     }
+
+    fn set_custom_status(&mut self, status: u8) -> ClientResult<'_, reply::SetCustomStatus, Self> {
+        self.request(request::SetCustomStatus { status })
+    }
 }
 
 /// Builder for [`ClientImplementation`][].

--- a/src/service.rs
+++ b/src/service.rs
@@ -18,6 +18,7 @@ pub use crate::store::{
     filestore::{ClientFilestore, Filestore, ReadDirFilesState, ReadDirState},
     keystore::{ClientKeystore, Keystore},
 };
+use crate::types::ui::Status;
 use crate::types::*;
 use crate::Bytes;
 
@@ -582,6 +583,11 @@ impl<P: Platform> ServiceResources<P> {
             Request::Wink(request) => {
                 self.platform.user_interface().wink(request.duration);
                 Ok(Reply::Wink(reply::Wink {}))
+            }
+
+            Request::SetCustomStatus(request) => {
+                self.platform.user_interface().set_status(Status::Custom(request.status));
+                Ok(Reply::SetCustomStatus(reply::SetCustomStatus {}))
             }
 
             Request::CreateCounter(request) => {

--- a/src/types.rs
+++ b/src/types.rs
@@ -175,6 +175,7 @@ pub mod ui {
         WaitingForUserPresence,
         Processing,
         Error,
+        Custom(u8),
     }
 }
 


### PR DESCRIPTION
This patch adds a custom UI status that can be defined and handled by the runner.  Applications that want to use this status should have a configuration option that lets the runner provide a value to use for that status.  The runner is responsible for correctly handling this status value.

Fixes https://github.com/Nitrokey/trussed/issues/5