### PR TITLE
Implement streaming encryption for files.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ aes = { version = "0.8", default-features = false }
 cbc = "0.1.2"
 blake2 = { version = "0.10", default-features = false, optional = true }
 chacha20 = { version = "0.9", default-features = false }
-chacha20poly1305 = { version = "0.10", default-features = false, features = ["heapless", "reduced-round", "aead"] }
+chacha20poly1305 = { version = "0.10", default-features = false, features = ["heapless", "reduced-round", "stream"] }
 des = { version = "0.8", optional = true }
 hmac = "0.12"
 sha-1 = { version = "0.10", default-features = false, optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ aes = { version = "0.8", default-features = false }
 cbc = "0.1.2"
 blake2 = { version = "0.10", default-features = false, optional = true }
 chacha20 = { version = "0.9", default-features = false }
-chacha20poly1305 = { version = "0.10", default-features = false, features = ["heapless", "reduced-round"] }
+chacha20poly1305 = { version = "0.10", default-features = false, features = ["heapless", "reduced-round", "aead"] }
 des = { version = "0.8", optional = true }
 hmac = "0.12"
 sha-1 = { version = "0.10", default-features = false, optional = true }

--- a/src/api.rs
+++ b/src/api.rs
@@ -51,8 +51,8 @@ generate_enums! {
     Sign: 18
     WriteFile: 19
     StartChunkedWrite: 66
+    StartChunkedRead: 72
     WriteChunk: 67
-    FlushChunks: 68
     AbortChunkedWrite: 69
     UnsafeInjectKey: 20
     UnsafeInjectSharedKey: 21
@@ -250,9 +250,6 @@ pub mod request {
           - location: Location
           - path: PathBuf
         ReadChunk:
-          - location: Location
-          - pos: OpenSeekFrom
-          - path: PathBuf
 
         Metadata:
           - location: Location
@@ -300,17 +297,14 @@ pub mod request {
           - data: Message
           - user_attribute: Option<UserAttribute>
 
+        StartChunkedRead:
+          - location: Location
+          - path: PathBuf
+
         WriteChunk:
-          - location: Location
-          - pos: OpenSeekFrom
-          - path: PathBuf
           - data: Message
-        FlushChunks:
-          - location: Location
-          - path: PathBuf
+
         AbortChunkedWrite:
-          - location: Location
-          - path: PathBuf
 
         UnsafeInjectKey:
           - mechanism: Mechanism        // -> implies key type
@@ -508,8 +502,11 @@ pub mod reply {
 
         WriteFile:
         StartChunkedWrite:
+        StartChunkedRead:
+          - data: Message
+          - len: usize
+
         WriteChunk:
-        FlushChunks:
         AbortChunkedWrite:
             - aborted: bool
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -51,7 +51,9 @@ generate_enums! {
     Sign: 18
     WriteFile: 19
     StartChunkedWrite: 66
+    StartEncryptedChunkedWrite: 73
     StartChunkedRead: 72
+    StartEncryptedChunkedRead: 74
     WriteChunk: 67
     AbortChunkedWrite: 69
     UnsafeInjectKey: 20
@@ -294,8 +296,19 @@ pub mod request {
         StartChunkedWrite:
           - location: Location
           - path: PathBuf
-          - data: Message
           - user_attribute: Option<UserAttribute>
+
+        StartEncryptedChunkedWrite:
+          - location: Location
+          - path: PathBuf
+          - user_attribute: Option<UserAttribute>
+          - key: KeyId
+          - nonce: ShortData
+
+        StartEncryptedChunkedRead:
+          - location: Location
+          - path: PathBuf
+          - key: KeyId
 
         StartChunkedRead:
           - location: Location
@@ -502,9 +515,11 @@ pub mod reply {
 
         WriteFile:
         StartChunkedWrite:
+        StartEncryptedChunkedWrite:
         StartChunkedRead:
           - data: Message
           - len: usize
+        StartEncryptedChunkedRead:
 
         WriteChunk:
         AbortChunkedWrite:

--- a/src/client.rs
+++ b/src/client.rs
@@ -671,17 +671,8 @@ pub trait FilesystemClient: PollClient {
     }
 
     // Read part of a file, up to 1KiB starting at `pos`
-    fn read_file_chunk(
-        &mut self,
-        location: Location,
-        path: PathBuf,
-        pos: OpenSeekFrom,
-    ) -> ClientResult<'_, reply::ReadChunk, Self> {
-        self.request(request::ReadChunk {
-            location,
-            path,
-            pos,
-        })
+    fn read_file_chunk(&mut self) -> ClientResult<'_, reply::ReadChunk, Self> {
+        self.request(request::ReadChunk {})
     }
 
     /// Fetch the Metadata for a file or directory
@@ -744,41 +735,24 @@ pub trait FilesystemClient: PollClient {
         })
     }
 
+    fn start_chunked_read(
+        &mut self,
+        location: Location,
+        path: PathBuf,
+    ) -> ClientResult<'_, reply::StartChunkedRead, Self> {
+        self.request(request::StartChunkedRead { location, path })
+    }
+
     /// Write part of a file
     ///
     /// See [`start_chunked_write`](FilesystemClient::start_chunked_write).
-    fn write_file_chunk(
-        &mut self,
-        location: Location,
-        path: PathBuf,
-        data: Message,
-        pos: OpenSeekFrom,
-    ) -> ClientResult<'_, reply::WriteChunk, Self> {
-        self.request(request::WriteChunk {
-            location,
-            path,
-            data,
-            pos,
-        })
-    }
-
-    /// Flush a file opened with [`start_chunked_write`](FilesystemClient::start_chunked_write).
-    /// Only after this will the content of the file be readable
-    fn flush_chunks(
-        &mut self,
-        location: Location,
-        path: PathBuf,
-    ) -> ClientResult<'_, reply::FlushChunks, Self> {
-        self.request(request::FlushChunks { location, path })
+    fn write_file_chunk(&mut self, data: Message) -> ClientResult<'_, reply::WriteChunk, Self> {
+        self.request(request::WriteChunk { data })
     }
 
     /// Abort writes to a file opened with [`start_chunked_write`](FilesystemClient::start_chunked_write).
-    fn abort_chunked_write(
-        &mut self,
-        location: Location,
-        path: PathBuf,
-    ) -> ClientResult<'_, reply::AbortChunkedWrite, Self> {
-        self.request(request::AbortChunkedWrite { location, path })
+    fn abort_chunked_write(&mut self) -> ClientResult<'_, reply::AbortChunkedWrite, Self> {
+        self.request(request::AbortChunkedWrite {})
     }
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -724,14 +724,42 @@ pub trait FilesystemClient: PollClient {
         &mut self,
         location: Location,
         path: PathBuf,
-        data: Message,
         user_attribute: Option<UserAttribute>,
     ) -> ClientResult<'_, reply::StartChunkedWrite, Self> {
         self.request(request::StartChunkedWrite {
             location,
             path,
-            data,
             user_attribute,
+        })
+    }
+
+    fn start_encrypted_chunked_write(
+        &mut self,
+        location: Location,
+        path: PathBuf,
+        key: KeyId,
+        nonce: ShortData,
+        user_attribute: Option<UserAttribute>,
+    ) -> ClientResult<'_, reply::StartEncryptedChunkedWrite, Self> {
+        self.request(request::StartEncryptedChunkedWrite {
+            location,
+            path,
+            key,
+            user_attribute,
+            nonce,
+        })
+    }
+
+    fn start_encrypted_chunked_read(
+        &mut self,
+        location: Location,
+        path: PathBuf,
+        key: KeyId,
+    ) -> ClientResult<'_, reply::StartEncryptedChunkedRead, Self> {
+        self.request(request::StartEncryptedChunkedRead {
+            location,
+            path,
+            key,
         })
     }
 
@@ -742,7 +770,6 @@ pub trait FilesystemClient: PollClient {
     ) -> ClientResult<'_, reply::StartChunkedRead, Self> {
         self.request(request::StartChunkedRead { location, path })
     }
-
     /// Write part of a file
     ///
     /// See [`start_chunked_write`](FilesystemClient::start_chunked_write).

--- a/src/store/filestore.rs
+++ b/src/store/filestore.rs
@@ -107,13 +107,7 @@ pub trait Filestore {
         location: Location,
         data: &[u8],
     ) -> Result<()>;
-    fn write_chunk(
-        &mut self,
-        path: &PathBuf,
-        location: Location,
-        data: &[u8],
-        pos: OpenSeekFrom,
-    ) -> Result<()>;
+    fn write_chunk(&mut self, path: &PathBuf, location: Location, data: &[u8]) -> Result<()>;
     fn flush_chunks(&mut self, path: &PathBuf, location: Location) -> Result<()>;
     fn abort_chunked_write(&mut self, path: &PathBuf, location: Location) -> bool;
     fn exists(&mut self, path: &PathBuf, location: Location) -> bool;
@@ -416,15 +410,15 @@ impl<S: Store> Filestore for ClientFilestore<S> {
         store::store(self.store, Location::Volatile, &path, data)
     }
 
-    fn write_chunk(
-        &mut self,
-        path: &PathBuf,
-        location: Location,
-        data: &[u8],
-        pos: OpenSeekFrom,
-    ) -> Result<()> {
+    fn write_chunk(&mut self, path: &PathBuf, location: Location, data: &[u8]) -> Result<()> {
         let path = self.chunks_path(path, location)?;
-        store::write_chunk(self.store, Location::Volatile, &path, data, pos)
+        store::write_chunk(
+            self.store,
+            Location::Volatile,
+            &path,
+            data,
+            OpenSeekFrom::End(0),
+        )
     }
 
     fn abort_chunked_write(&mut self, path: &PathBuf, location: Location) -> bool {

--- a/src/types.rs
+++ b/src/types.rs
@@ -258,6 +258,22 @@ impl<B: Default> From<CoreContext> for Context<B> {
     }
 }
 
+pub struct ChunkedReadState {
+    pub path: PathBuf,
+    pub location: Location,
+    pub offset: usize,
+}
+
+pub struct ChunkedWriteState {
+    pub path: PathBuf,
+    pub location: Location,
+}
+
+pub enum ChunkedIoState {
+    Read(ChunkedReadState),
+    Write(ChunkedWriteState),
+}
+
 // The "CoreContext" struct is the closest equivalent to a PCB that Trussed
 // currently has. Trussed currently uses it to choose the client-specific
 // subtree in the filesystem (see docs in src/store.rs) and to maintain
@@ -266,6 +282,7 @@ pub struct CoreContext {
     pub path: PathBuf,
     pub read_dir_state: Option<ReadDirState>,
     pub read_dir_files_state: Option<ReadDirFilesState>,
+    pub chunked_io_state: Option<ChunkedIoState>,
 }
 
 impl CoreContext {
@@ -274,6 +291,7 @@ impl CoreContext {
             path,
             read_dir_state: None,
             read_dir_files_state: None,
+            chunked_io_state: None,
         }
     }
 }

--- a/tests/filesystem.rs
+++ b/tests/filesystem.rs
@@ -4,7 +4,7 @@ use trussed::{
     client::{CryptoClient, FilesystemClient},
     error::Error,
     syscall, try_syscall,
-    types::{Bytes, Location, Mechanism, OpenSeekFrom, PathBuf, StorageAttributes},
+    types::{Bytes, Location, Mechanism, PathBuf, StorageAttributes},
     utils,
 };
 
@@ -104,10 +104,9 @@ fn test_write_all(location: Location) {
         let path = PathBuf::from("foo");
         utils::write_all(client, location, path.clone(), &[48; 1234], None).unwrap();
 
-        let data =
-            syscall!(client.read_file_chunk(location, path.clone(), OpenSeekFrom::Start(0))).data;
+        let data = syscall!(client.start_chunked_read(location, path.clone())).data;
         assert_eq!(&data, &[48; 1024]);
-        let data = syscall!(client.read_file_chunk(location, path, OpenSeekFrom::Start(1024))).data;
+        let data = syscall!(client.read_file_chunk()).data;
         assert_eq!(&data, &[48; 1234 - 1024]);
     });
 }
@@ -117,7 +116,7 @@ fn test_write_all_small(location: Location) {
         let path = PathBuf::from("foo2");
         utils::write_all(client, location, path.clone(), &[48; 1023], None).unwrap();
 
-        let data = syscall!(client.read_file_chunk(location, path, OpenSeekFrom::Start(0))).data;
+        let data = syscall!(client.start_chunked_read(location, path)).data;
         assert_eq!(&data, &[48; 1023]);
     });
 }

--- a/tests/filesystem.rs
+++ b/tests/filesystem.rs
@@ -104,7 +104,7 @@ fn test_write_all(location: Location) {
         let path = PathBuf::from("foo");
         utils::write_all(client, location, path.clone(), &[48; 1234], None).unwrap();
 
-        let data = syscall!(client.start_chunked_read(location, path.clone())).data;
+        let data = syscall!(client.start_chunked_read(location, path)).data;
         assert_eq!(&data, &[48; 1024]);
         let data = syscall!(client.read_file_chunk()).data;
         assert_eq!(&data, &[48; 1234 - 1024]);


### PR DESCRIPTION
This significantly changes the original chunked API, to make it mostly compatible with the encrypted version.

TODO
=====

- [ ] Update documentation
- [ ] Determine nonce reuse risk:
  Nonce for the streaming APIs are of the form: `<nonce> <chunk counter> <is last>`, with the nonce being 8 bytes, the chunk counter 31 bits and the`is_last` flag 1 bit. This makes the kind of key `Symmetric32Nonce` unusable (or we need to increment by $2^4$ to avoid collisions. This also makes the potential risk for colision in the 8 byte nonce much more likely, we need to calculate it and make sure it's acceptable.

Make it an extension?
=================

Essentially once the fliestore trait is updated with what we need, the streaming api (encrypted and not) could very well be an extension. It might be more maintainable this way.