### PR TITLE
Remove unnecessary request copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added optional support for API extensions in `serde_extensions` module
   behind the `serde-extensions` feature.
 - Added `types::Path` re-export of `littlefs2::path::Path`.
+- Reduced stack usage of `Service::process`.
 
 ### Changed
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -815,7 +815,7 @@ impl<P: Platform, D: Dispatch> Service<P, D> {
         let resources = &mut self.resources;
 
         for ep in eps.iter_mut() {
-            if let Some(request) = ep.interchange.take_request() {
+            if let Ok(request) = ep.interchange.request() {
                 resources
                     .platform
                     .user_interface()
@@ -824,12 +824,12 @@ impl<P: Platform, D: Dispatch> Service<P, D> {
 
                 // resources.currently_serving = ep.client_id.clone();
                 let reply_result = if ep.backends.is_empty() {
-                    resources.reply_to(&mut ep.ctx.core, &request)
+                    resources.reply_to(&mut ep.ctx.core, request)
                 } else {
                     let mut reply_result = Err(Error::RequestNotAvailable);
                     for backend in ep.backends {
                         reply_result =
-                            resources.dispatch(&mut self.dispatch, backend, &mut ep.ctx, &request);
+                            resources.dispatch(&mut self.dispatch, backend, &mut ep.ctx, request);
                         if reply_result != Err(Error::RequestNotAvailable) {
                             break;
                         }


### PR DESCRIPTION
This patch removes an unnecessary take_request call from Service::process, reducing the stack usage by roughly 5 kB.