### PR TITLE
ClientFilestore: make `dat` optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,4 +133,4 @@ features = ["serde-extensions", "virt"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [patch.crates-io]
-littlefs2 = { git = "https://github.com/trussed-dev/littlefs2.git", rev = "ebd27e49ca321089d01d8c9b169c4aeb58ceeeca" }
+littlefs2 = { git = "https://github.com/sosthene-nitrokey/littlefs2.git", rev = "2b45a7559ff44260c6dd693e4cb61f54ae5efc53" }

--- a/src/api.rs
+++ b/src/api.rs
@@ -244,7 +244,7 @@ pub mod request {
         ReadDirFirst:
           - location: Location
           - dir: PathBuf
-          - not_before_filename: Option<PathBuf>
+          - not_before: Option<(PathBuf, bool)>
 
         ReadDirNext:
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -598,6 +598,9 @@ pub trait FilesystemClient: PollClient {
         self.request(request::DebugDumpStore {})
     }
 
+    /// Open a directory for iteration with `read_dir_next`
+    ///
+    /// For optimization, not_before_filename can be passed to begin the iteration at that file.
     fn read_dir_first(
         &mut self,
         location: Location,
@@ -607,7 +610,27 @@ pub trait FilesystemClient: PollClient {
         self.request(request::ReadDirFirst {
             location,
             dir,
-            not_before_filename,
+            not_before: not_before_filename.map(|p| (p, true)),
+        })
+    }
+
+    /// Open a directory for iteration with `read_dir_next`
+    ///
+    /// For optimization, not_before_filename can be passed to begin the iteration after the first file that is "alphabetically" before the original file
+    ///
+    /// <div class="warning">
+    /// The notion used here for "alphabetical" does not correspond to the order of iteration yielded by littlefs. This function should be used with caution. If `not_before_filename` was yielded from a previous use of read_dir, it can lead to entries being repeated.
+    /// </div>
+    fn read_dir_first_alphabetical(
+        &mut self,
+        location: Location,
+        dir: PathBuf,
+        not_before_filename: Option<PathBuf>,
+    ) -> ClientResult<'_, reply::ReadDirFirst, Self> {
+        self.request(request::ReadDirFirst {
+            location,
+            dir,
+            not_before: not_before_filename.map(|p| (p, false)),
         })
     }
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -404,7 +404,10 @@ impl<P: Platform> ServiceResources<P> {
                 let maybe_entry = match filestore.read_dir_first(
                     &request.dir,
                     request.location,
-                    request.not_before_filename.as_deref(),
+                    request
+                        .not_before
+                        .as_ref()
+                        .map(|(path, require_equal)| (&**path, *require_equal)),
                 )? {
                     Some((entry, read_dir_state)) => {
                         ctx.read_dir_state = Some(read_dir_state);

--- a/src/service.rs
+++ b/src/service.rs
@@ -113,6 +113,11 @@ impl<P: Platform> ServiceResources<P> {
         ClientFilestore::new(client_id, self.platform.store())
     }
 
+    /// Get access to the filestore for the client without the `dat` intermediary
+    pub fn raw_filestore(&mut self, client_id: PathBuf) -> ClientFilestore<P::S> {
+        ClientFilestore::new_raw(client_id, self.platform.store())
+    }
+
     pub fn trussed_filestore(&mut self) -> ClientFilestore<P::S> {
         ClientFilestore::new(PathBuf::from("trussed"), self.platform.store())
     }

--- a/src/store/filestore.rs
+++ b/src/store/filestore.rs
@@ -29,19 +29,29 @@ use littlefs2::{
     path::{Path, PathBuf},
 };
 
-pub type ClientId = PathBuf;
-
 pub struct ClientFilestore<S>
 where
     S: Store,
 {
-    client_id: ClientId,
+    base: PathBuf,
     store: S,
 }
 
 impl<S: Store> ClientFilestore<S> {
-    pub fn new(client_id: ClientId, store: S) -> Self {
-        Self { client_id, store }
+    /// Create a filestore that stores files in `<client_id>/dat/<file_path>`
+    pub fn new(client_id: PathBuf, store: S) -> Self {
+        let mut base = client_id;
+        base.push(path!("dat"));
+        Self { base, store }
+    }
+
+    /// Create a filestore that stores files in `<client_id>/<file_path>`
+    ///
+    /// Unlike [`ClientFilestore::new`](), it does not have the `dat` intermediary.
+    /// It is meant to be used by custom backends to save space in case the `dat` folder is not used and only wastes a littlefs block.
+    pub fn new_raw(client_id: PathBuf, store: S) -> Self {
+        let base = client_id;
+        Self { base, store }
     }
 
     /// Client files are store below `/<client_id>/dat/`.
@@ -51,9 +61,7 @@ impl<S: Store> ClientFilestore<S> {
             return Err(Error::InvalidPath);
         }
 
-        let mut path = PathBuf::new();
-        path.push(&self.client_id);
-        path.push(path!("dat"));
+        let mut path = self.base.clone();
         path.push(client_path);
         Ok(path)
     }

--- a/tests/filesystem.rs
+++ b/tests/filesystem.rs
@@ -1,5 +1,7 @@
 #![cfg(feature = "virt")]
 
+use std::assert_eq;
+
 use trussed::{
     client::{CryptoClient, FilesystemClient},
     error::Error,
@@ -85,15 +87,217 @@ fn iterating(location: Location) {
     });
 }
 
+fn iterating_first(location: Location) {
+    use littlefs2::path;
+    client::get(|client| {
+        let files = [
+            path!("foo"),
+            path!("bar"),
+            path!("baz"),
+            path!("foobar"),
+            path!("foobaz"),
+        ];
+
+        let files_sorted_lfs = {
+            let mut files = files;
+            files.sort_by(|a, b| a.cmp_lfs(b));
+            files
+        };
+
+        assert_eq!(
+            files_sorted_lfs,
+            [
+                path!("bar"),
+                path!("baz"),
+                path!("foobar"),
+                path!("foobaz"),
+                path!("foo"),
+            ]
+        );
+
+        let files_sorted_str = {
+            let mut files = files;
+            files.sort_by(|a, b| a.cmp_str(b));
+            files
+        };
+        assert_eq!(
+            files_sorted_str,
+            [
+                path!("bar"),
+                path!("baz"),
+                path!("foo"),
+                path!("foobar"),
+                path!("foobaz"),
+            ]
+        );
+
+        for f in files {
+            syscall!(client.write_file(
+                location,
+                PathBuf::from(f),
+                Bytes::from_slice(f.as_ref().as_bytes()).unwrap(),
+                None
+            ));
+        }
+
+        let first_entry =
+            syscall!(client.read_dir_first_alphabetical(location, PathBuf::from(""), None))
+                .entry
+                .unwrap();
+        assert_eq!(first_entry.path(), files_sorted_lfs[0]);
+        for f in &files_sorted_lfs[1..] {
+            let entry = syscall!(client.read_dir_next()).entry.unwrap();
+            assert_eq!(&entry.path(), f);
+        }
+        assert!(syscall!(client.read_dir_next()).entry.is_none());
+
+        let first_entry = syscall!(client.read_dir_first_alphabetical(
+            location,
+            PathBuf::from(""),
+            Some(PathBuf::from("fo"))
+        ))
+        .entry
+        .unwrap();
+        assert_eq!(first_entry.path(), path!("foobar"));
+
+        for f in &(files_sorted_lfs[3..]) {
+            let entry = syscall!(client.read_dir_next()).entry.unwrap();
+            assert_eq!(&entry.path(), f);
+        }
+        assert!(syscall!(client.read_dir_next()).entry.is_none());
+    });
+}
+
+fn iterating_files_and_dirs(location: Location) {
+    use littlefs2::path;
+    client::get(|client| {
+        let files = [
+            path!("foo"),
+            path!("bar"),
+            path!("baz"),
+            path!("foobar"),
+            path!("foobaz"),
+        ];
+
+        for f in files {
+            syscall!(client.write_file(
+                location,
+                PathBuf::from(f),
+                Bytes::from_slice(f.as_ref().as_bytes()).unwrap(),
+                None
+            ));
+        }
+
+        let directories = [
+            path!("dir"),
+            path!("foodir"),
+            path!("bardir"),
+            path!("bazdir"),
+            path!("foobardir"),
+            path!("foobazdir"),
+        ];
+
+        for d in directories {
+            let mut file_path = PathBuf::from(d);
+            file_path.push(path!("file"));
+
+            syscall!(client.write_file(
+                location,
+                file_path.clone(),
+                Bytes::from_slice(file_path.as_ref().as_bytes()).unwrap(),
+                None
+            ));
+        }
+
+        let all_entries: Vec<_> = files.into_iter().chain(directories).collect();
+        let all_entries_sorted_str = {
+            let mut all_entries = all_entries.clone();
+            all_entries.sort_by(|a, b| a.cmp_str(b));
+            all_entries
+        };
+
+        assert_eq!(
+            all_entries_sorted_str,
+            [
+                path!("bar"),
+                path!("bardir"),
+                path!("baz"),
+                path!("bazdir"),
+                path!("dir"),
+                path!("foo"),
+                path!("foobar"),
+                path!("foobardir"),
+                path!("foobaz"),
+                path!("foobazdir"),
+                path!("foodir"),
+            ]
+        );
+
+        let all_entries_sorted_lfs = {
+            let mut all_entries = all_entries.clone();
+            all_entries.sort_by(|a, b| a.cmp_lfs(b));
+            all_entries
+        };
+
+        assert_eq!(
+            all_entries_sorted_lfs,
+            [
+                path!("bardir"),
+                path!("bar"),
+                path!("bazdir"),
+                path!("baz"),
+                path!("dir"),
+                path!("foobardir"),
+                path!("foobar"),
+                path!("foobazdir"),
+                path!("foobaz"),
+                path!("foodir"),
+                path!("foo"),
+            ]
+        );
+
+        let first_entry =
+            syscall!(client.read_dir_first_alphabetical(location, PathBuf::from(""), None))
+                .entry
+                .unwrap();
+        assert_eq!(first_entry.path(), all_entries_sorted_lfs[0]);
+        for f in &all_entries_sorted_lfs[1..] {
+            let entry = syscall!(client.read_dir_next()).entry.unwrap();
+            assert_eq!(&entry.path(), f);
+        }
+        assert!(syscall!(client.read_dir_next()).entry.is_none());
+
+        let first_entry = syscall!(client.read_dir_first_alphabetical(
+            location,
+            PathBuf::from(""),
+            Some(PathBuf::from("dir"))
+        ))
+        .entry
+        .unwrap();
+        assert_eq!(first_entry.path(), all_entries_sorted_lfs[4]);
+        for f in &all_entries_sorted_lfs[5..] {
+            let entry = syscall!(client.read_dir_next()).entry.unwrap();
+            assert_eq!(&entry.path(), f);
+        }
+        assert!(syscall!(client.read_dir_next()).entry.is_none());
+    });
+}
+
 #[test]
 fn iterating_internal() {
     iterating(Location::Internal);
+    iterating_first(Location::Internal);
+    iterating_files_and_dirs(Location::Internal);
 }
 #[test]
 fn iterating_external() {
     iterating(Location::External);
+    iterating_first(Location::External);
+    iterating_files_and_dirs(Location::External);
 }
 #[test]
 fn iterating_volatile() {
     iterating(Location::Volatile);
+    iterating_first(Location::Volatile);
+    iterating_files_and_dirs(Location::Volatile);
 }


### PR DESCRIPTION
The `dat` intermediary directory is not always useful for custom backends, and in that case it wastes a littlefs storage block.

Built on top of #33 