### PR TITLE
Add must_use attributes on futures.

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -119,6 +119,7 @@ pub trait PollClient {
     }
 }
 
+#[must_use = "Syscalls must be polled with the `syscall` macro"]
 pub struct FutureResult<'c, T, C: ?Sized>
 where
     C: PollClient,

--- a/src/serde_extensions.rs
+++ b/src/serde_extensions.rs
@@ -180,6 +180,7 @@ where
 /// A result returned by [`ExtensionClient`][] and clients using it.
 pub type ExtensionResult<'a, E, T, C> = Result<ExtensionFutureResult<'a, E, T, C>, ClientError>;
 
+#[must_use = "Syscalls must be polled with the `syscall` macro"]
 /// A future of an [`ExtensionResult`][].
 pub struct ExtensionFutureResult<'c, E, T, C: ?Sized> {
     client: &'c mut C,


### PR DESCRIPTION
Prior to that there would be no warning when forgetting to use `(try_)syscall`.